### PR TITLE
feat(parsed_transaction_history): add transaction pagination

### DIFF
--- a/examples/get_parsed_transaction_history.rs
+++ b/examples/get_parsed_transaction_history.rs
@@ -9,14 +9,12 @@ async fn main() -> Result<(), HeliusError> {
 
     let helius: Helius = Helius::new(api_key, cluster).unwrap();
 
-    let request: ParseTransactionHistoryRequest = ParseTransactionHistoryRequest {
+    let request: ParsedTransactionHistoryRequest = ParsedTransactionHistoryRequest {
         address: "2k5AXX4guW9XwRQ1AKCpAuUqgWDpQpwFfpVFh3hnm2Ha".to_string(),
         before: None,
     };
 
-    let response: Result<Vec<EnhancedTransaction>, HeliusError> = helius
-        .parsed_transaction_history(request)
-        .await;
+    let response: Result<Vec<EnhancedTransaction>, HeliusError> = helius.parsed_transaction_history(request).await;
 
     println!("Assets: {:?}", response);
 

--- a/examples/get_parsed_transaction_history.rs
+++ b/examples/get_parsed_transaction_history.rs
@@ -9,9 +9,15 @@ async fn main() -> Result<(), HeliusError> {
 
     let helius: Helius = Helius::new(api_key, cluster).unwrap();
 
+    let request: ParseTransactionHistoryRequest = ParseTransactionHistoryRequest {
+        address: "2k5AXX4guW9XwRQ1AKCpAuUqgWDpQpwFfpVFh3hnm2Ha".to_string(),
+        before: None,
+    };
+
     let response: Result<Vec<EnhancedTransaction>, HeliusError> = helius
-        .parsed_transaction_history("2k5AXX4guW9XwRQ1AKCpAuUqgWDpQpwFfpVFh3hnm2Ha")
+        .parsed_transaction_history(request)
         .await;
+
     println!("Assets: {:?}", response);
 
     Ok(())

--- a/src/enhanced_transactions.rs
+++ b/src/enhanced_transactions.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use crate::types::{EnhancedTransaction, ParseTransactionsRequest};
+use crate::types::{EnhancedTransaction, ParseTransactionsRequest, ParseTransactionHistoryRequest};
 use crate::Helius;
 
 use reqwest::{Method, Url};
@@ -31,14 +31,20 @@ impl Helius {
     ///
     /// # Arguments
     /// * `address` - An address for which a given parsed transaction history will be retrieved
+    /// * `before` - An optional signature to get history before, useful for pagination
     ///
     /// # Returns
     /// A `Result` wrapping a vector of `EnhancedTransaction`s
-    pub async fn parsed_transaction_history(&self, address: &str) -> Result<Vec<EnhancedTransaction>> {
-        let url: String = format!(
+    pub async fn parsed_transaction_history(&self, request: ParseTransactionHistoryRequest) -> Result<Vec<EnhancedTransaction>> {
+        let mut url: String = format!(
             "{}v0/addresses/{}/transactions?api-key={}",
-            self.config.endpoints.api, address, self.config.api_key
+            self.config.endpoints.api, request.address, self.config.api_key
         );
+
+        if let Some(before) = request.before {
+            url = format!("{}&before={}", url, before);
+        }
+
         let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
 
         self.rpc_client.handler.send(Method::GET, parsed_url, None::<&()>).await

--- a/src/enhanced_transactions.rs
+++ b/src/enhanced_transactions.rs
@@ -1,5 +1,5 @@
 use crate::error::Result;
-use crate::types::{EnhancedTransaction, ParseTransactionsRequest, ParseTransactionHistoryRequest};
+use crate::types::{EnhancedTransaction, ParseTransactionsRequest, ParsedTransactionHistoryRequest};
 use crate::Helius;
 
 use reqwest::{Method, Url};
@@ -8,7 +8,8 @@ impl Helius {
     /// Parses transactions given an array of transaction IDs
     ///
     /// # Arguments
-    /// * `transactions` - A vector of transaction IDs to be parsed
+    /// * `ParseTransactionsRequest` - A parse transaction request, which includes:
+    /// - A vector of transaction IDs to be parsed
     ///
     /// # Returns
     /// A `Result` wrapping a vector of `EnhancedTransaction`s
@@ -30,12 +31,16 @@ impl Helius {
     /// Retrieves a parsed transaction history for a specific address
     ///
     /// # Arguments
-    /// * `address` - An address for which a given parsed transaction history will be retrieved
-    /// * `before` - An optional signature to get history before, useful for pagination
+    /// * `ParsedTransactionHistoryRequest` - A parsed transaction history request, which includes:
+    /// - An address for which a given parsed transaction history will be retrieved
+    /// - An optional `before` parameter that, when provided, fetches the parsed transaction history before the given signature. This is useful for pagination
     ///
     /// # Returns
     /// A `Result` wrapping a vector of `EnhancedTransaction`s
-    pub async fn parsed_transaction_history(&self, request: ParseTransactionHistoryRequest) -> Result<Vec<EnhancedTransaction>> {
+    pub async fn parsed_transaction_history(
+        &self,
+        request: ParsedTransactionHistoryRequest,
+    ) -> Result<Vec<EnhancedTransaction>> {
         let mut url: String = format!(
             "{}v0/addresses/{}/transactions?api-key={}",
             self.config.endpoints.api, request.address, self.config.api_key

--- a/src/types/enhanced_transaction_types.rs
+++ b/src/types/enhanced_transaction_types.rs
@@ -210,6 +210,12 @@ pub struct ParseTransactionsRequest {
     pub transactions: Vec<String>,
 }
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ParseTransactionHistoryRequest {
+    pub address: String,
+    pub before: Option<String>,
+}
+
 /// We have a limit of 100 transactions per call, so this helps split the signatures into different chunks
 impl ParseTransactionsRequest {
     pub fn from_slice(signatures: &[String]) -> Vec<Self> {

--- a/src/types/enhanced_transaction_types.rs
+++ b/src/types/enhanced_transaction_types.rs
@@ -211,7 +211,7 @@ pub struct ParseTransactionsRequest {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct ParseTransactionHistoryRequest {
+pub struct ParsedTransactionHistoryRequest {
     pub address: String,
     pub before: Option<String>,
 }


### PR DESCRIPTION
Added ability paginate the results of the request in the transaction history, by doing the following:

1. Creating a new request type called ParseTransactionHistoryRequest that has an `address` String and an Option `before` String
2. Updated `parsed_transaction_history` to input the new type, and update the API call if `before` exists. Updated documentation above it.
3. Updated the example to reflect the change

I've never contributed to an open-source project, so please forgive me if this is the wrong process for suggesting edits or updates to the module. 

I looked through the code to adhere to similar structures that y'all used in other aspects, but either way this should be a complete fix here or a good start to this implementation.

Any feedback or comments please let me know. Otherwise it should be good to go.

Cheers,

rhh