### PR TITLE
fix(priority_fee_estimate): Change `None` to `Min` and Add `recommended` Option

### DIFF
--- a/examples/get_priority_fee_estimate.rs
+++ b/examples/get_priority_fee_estimate.rs
@@ -17,6 +17,7 @@ async fn main() -> Result<(), HeliusError> {
             include_all_priority_fee_levels: None,
             transaction_encoding: None,
             lookback_slots: None,
+            recommended: None,
         }),
     };
 

--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -154,7 +154,7 @@ impl MintApiAuthority {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum PriorityLevel {
-    None,
+    Min,
     Low,
     Medium,
     High,

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -777,6 +777,7 @@ pub struct GetPriorityFeeEstimateOptions {
     pub include_all_priority_fee_levels: Option<bool>,
     pub transaction_encoding: Option<UiTransactionEncoding>,
     pub lookback_slots: Option<u8>,
+    pub recommended: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default)]

--- a/tests/rpc/test_get_priority_fee_estimate.rs
+++ b/tests/rpc/test_get_priority_fee_estimate.rs
@@ -62,6 +62,7 @@ async fn test_get_nft_editions_success() {
             include_all_priority_fee_levels: None,
             transaction_encoding: None,
             lookback_slots: None,
+            recommended: None,
         }),
     };
 
@@ -115,6 +116,7 @@ async fn test_get_nft_editions_failure() {
             include_all_priority_fee_levels: None,
             transaction_encoding: None,
             lookback_slots: None,
+            recommended: None,
         }),
     };
 


### PR DESCRIPTION
This PR aims to add a few fixes to the `priority_fee_estimate` method by changing the `None` enum type for `PriorityLevel` to `Min` and introduces the new `recommended` option