### PR TITLE
feat(optimized_transactions): Add `send_smart_transaction` Functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,8 @@ chrono = { version = "0.4.11", features = ["serde"] }
 solana-client = "1.18.12"
 solana-program = "1.18.12"
 serde-enum-str = "0.4.0"
+bincode = "1.3.3"
+base64 = "0.22.1"
 
 [dev-dependencies]
 mockito = "1.4.0"

--- a/examples/get_priority_fee_estimate.rs
+++ b/examples/get_priority_fee_estimate.rs
@@ -18,6 +18,7 @@ async fn main() -> Result<(), HeliusError> {
             transaction_encoding: None,
             lookback_slots: None,
             recommended: None,
+            include_vote: None,
         }),
     };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,12 @@
 use reqwest::{Error as ReqwestError, StatusCode};
 use serde_json::Error as SerdeJsonError;
 use solana_client::client_error::ClientError;
-use solana_sdk::message::CompileError;
-use solana_sdk::sanitize::SanitizeError;
-use solana_sdk::signature::SignerError;
+use solana_sdk::{
+    message::CompileError,
+    sanitize::SanitizeError,
+    signature::SignerError,
+    transaction::TransactionError,
+};
 use thiserror::Error;
 
 /// Represents all possible errors returned by the `Helius` client
@@ -81,6 +84,18 @@ pub enum HeliusError {
     /// This captures errors from the signing operations in the Solana SDK
     #[error("Signer error: {0}")]
     SignerError(#[from] SignerError),
+
+    /// Indicates that the transaction confirmation timed out
+    ///
+    /// For polling a transaction's confirmation status
+    #[error("Transaction confirmation timed out with error code {code}: {text}")]
+    Timeout { code: StatusCode, text: String },
+
+    /// Represents transaction errors from the Solana SDK
+    ///
+    /// This captures errors that occur when processing transactions
+    #[error("Transaction error: {0}")]
+    TransactionError(#[from] TransactionError),
 
     /// Indicates the request lacked valid authentication credentials
     ///

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,9 @@
 use reqwest::{Error as ReqwestError, StatusCode};
 use serde_json::Error as SerdeJsonError;
+use solana_client::client_error::ClientError;
+use solana_sdk::sanitize::SanitizeError;
+use solana_sdk::signature::SignerError;
+use solana_sdk::message::CompileError;
 use thiserror::Error;
 
 /// Represents all possible errors returned by the `Helius` client
@@ -13,6 +17,18 @@ pub enum HeliusError {
     /// or contains invalid data
     #[error("Bad request to {path}: {text}")]
     BadRequest { path: String, text: String },
+
+    /// Represents errors from the Solana client
+    ///
+    /// This captures errors from the Solana client library
+    #[error("Solana client error: {0}")]
+    ClientError(#[from] ClientError),
+
+    /// Represents compile errors from the Solana SDK
+    /// 
+    /// This captures all compile errors thrown by the Solana SDK
+    #[error("Compile error: {0}")]
+    CompileError(#[from] CompileError),
 
     /// Represents errors that occur internally with Helius and our servers
     ///
@@ -60,6 +76,12 @@ pub enum HeliusError {
     #[error("Serialization / Deserialization error: {0}")]
     SerdeJson(SerdeJsonError),
 
+    /// Represents errors from the Solana SDK for signing operations
+    ///
+    /// This captures errors from the signing operations in the Solana SDK
+    #[error("Signer error: {0}")]
+    SignerError(#[from] SignerError),
+
     /// Indicates the request lacked valid authentication credentials
     ///
     /// This error is returned in response to a missing, invalid, or expired API key
@@ -95,6 +117,12 @@ impl From<SerdeJsonError> for HeliusError {
     /// This allows for the seamless integration of JSON parsing errors into the broader error handling system
     fn from(err: SerdeJsonError) -> HeliusError {
         HeliusError::SerdeJson(err)
+    }
+}
+
+impl From<SanitizeError> for HeliusError {
+    fn from(err: SanitizeError) -> Self {
+        HeliusError::InvalidInput(err.to_string())
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,9 +1,9 @@
 use reqwest::{Error as ReqwestError, StatusCode};
 use serde_json::Error as SerdeJsonError;
 use solana_client::client_error::ClientError;
+use solana_sdk::message::CompileError;
 use solana_sdk::sanitize::SanitizeError;
 use solana_sdk::signature::SignerError;
-use solana_sdk::message::CompileError;
 use thiserror::Error;
 
 /// Represents all possible errors returned by the `Helius` client
@@ -25,7 +25,7 @@ pub enum HeliusError {
     ClientError(#[from] ClientError),
 
     /// Represents compile errors from the Solana SDK
-    /// 
+    ///
     /// This captures all compile errors thrown by the Solana SDK
     #[error("Compile error: {0}")]
     CompileError(#[from] CompileError),

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,10 +2,7 @@ use reqwest::{Error as ReqwestError, StatusCode};
 use serde_json::Error as SerdeJsonError;
 use solana_client::client_error::ClientError;
 use solana_sdk::{
-    message::CompileError,
-    sanitize::SanitizeError,
-    signature::SignerError,
-    transaction::TransactionError,
+    message::CompileError, sanitize::SanitizeError, signature::SignerError, transaction::TransactionError,
 };
 use thiserror::Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod enhanced_transactions;
 pub mod error;
 pub mod factory;
 pub mod mint_api;
+pub mod optimized_transaction;
 pub mod request_handler;
 pub mod rpc_client;
 pub mod types;

--- a/src/optimized_transaction.rs
+++ b/src/optimized_transaction.rs
@@ -1,0 +1,55 @@
+use crate::error::Result;
+use crate::Helius;
+use solana_client::rpc_response::{Response, RpcSimulateTransactionResult};
+use solana_sdk::{
+    address_lookup_table::AddressLookupTableAccount,
+    compute_budget::ComputeBudgetInstruction,
+    hash::Hash,
+    instruction::Instruction,
+    message::{v0, VersionedMessage},
+    pubkey::Pubkey,
+    transaction::VersionedTransaction,
+};
+
+impl Helius {
+    /// Simulates a transaction to get the total compute units consumed
+    ///
+    /// # Arguments
+    /// * `instructions` - The transaction instructions
+    /// * `payer` - The public key of the payer
+    /// * `lookup_tables` - The address lookup tables
+    ///
+    /// # Returns
+    /// The compute units consumed, or None if unsuccessful
+    pub async fn get_compute_units(
+        &self,
+        instructions: Vec<Instruction>,
+        payer: Pubkey,
+        lookup_tables: Vec<AddressLookupTableAccount>,
+    ) -> Result<Option<u64>> {
+        // Set the compute budget limit
+        let test_instructions: Vec<Instruction> = vec![ComputeBudgetInstruction::set_compute_unit_limit(1_400_000)]
+            .into_iter()
+            .chain(instructions)
+            .collect::<Vec<_>>();
+
+        // Fetch the latest blockhash
+        let recent_blockhash: Hash = self.connection().get_latest_blockhash()?;
+
+        // Create a v0::Message
+        let v0_message: v0::Message = v0::Message::try_compile(&payer, &test_instructions, &lookup_tables, recent_blockhash)?;
+        let versioned_message: VersionedMessage = VersionedMessage::V0(v0_message);
+
+        // Create an unsigned VersionedTransaction
+        let transaction: VersionedTransaction = VersionedTransaction {
+            signatures: vec![],
+            message: versioned_message,
+        };
+
+        // Simulate the transaction
+        let result: Response<RpcSimulateTransactionResult> = self.connection().simulate_transaction(&transaction)?;
+
+        // Return the units consumed or None if not available
+        Ok(result.value.units_consumed)
+    }
+}

--- a/src/optimized_transaction.rs
+++ b/src/optimized_transaction.rs
@@ -37,7 +37,8 @@ impl Helius {
         let recent_blockhash: Hash = self.connection().get_latest_blockhash()?;
 
         // Create a v0::Message
-        let v0_message: v0::Message = v0::Message::try_compile(&payer, &test_instructions, &lookup_tables, recent_blockhash)?;
+        let v0_message: v0::Message =
+            v0::Message::try_compile(&payer, &test_instructions, &lookup_tables, recent_blockhash)?;
         let versioned_message: VersionedMessage = VersionedMessage::V0(v0_message);
 
         // Create an unsigned VersionedTransaction

--- a/src/optimized_transaction.rs
+++ b/src/optimized_transaction.rs
@@ -4,7 +4,7 @@ use crate::Helius;
 
 use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
-use bincode::{ErrorKind, serialize};
+use bincode::{serialize, ErrorKind};
 use reqwest::StatusCode;
 use solana_client::rpc_config::RpcSendTransactionConfig;
 use solana_client::rpc_response::{Response, RpcSimulateTransactionResult};
@@ -120,7 +120,8 @@ impl Helius {
         transaction.try_sign(&[config.from_keypair], recent_blockhash)?;
 
         // Serialize the transaction
-        let serialized_transaction: Vec<u8> = serialize(&transaction).map_err(|e: Box<ErrorKind>| HeliusError::InvalidInput(e.to_string()))?;
+        let serialized_transaction: Vec<u8> =
+            serialize(&transaction).map_err(|e: Box<ErrorKind>| HeliusError::InvalidInput(e.to_string()))?;
 
         // Convert the serialized transaction to a Base64 string
         let transaction_base64: String = STANDARD.encode(&serialized_transaction);

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -8,8 +8,7 @@ use crate::types::{DisplayOptions, GetAssetOptions};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use solana_sdk::instruction::Instruction;
-use solana_sdk::signature::Keypair;
+use solana_sdk::{address_lookup_table::AddressLookupTableAccount, instruction::Instruction, signature::Keypair};
 
 /// Defines the available clusters supported by Helius
 #[derive(Debug, Clone, PartialEq)]
@@ -949,6 +948,7 @@ pub struct SmartTransactionConfig<'a> {
     pub from_keypair: &'a Keypair,
     pub skip_preflight_checks: Option<bool>,
     pub max_retries: Option<usize>,
+    pub lookup_tables: Option<Vec<AddressLookupTableAccount>>,
 }
 
 impl<'a> SmartTransactionConfig<'a> {
@@ -958,6 +958,7 @@ impl<'a> SmartTransactionConfig<'a> {
             from_keypair,
             skip_preflight_checks: None,
             max_retries: None,
+            lookup_tables: None,
         }
     }
 }

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -8,6 +8,9 @@ use crate::types::{DisplayOptions, GetAssetOptions};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use solana_sdk::instruction::Instruction;
+use solana_sdk::signature::Keypair;
+
 /// Defines the available clusters supported by Helius
 #[derive(Debug, Clone, PartialEq)]
 pub enum Cluster {
@@ -939,4 +942,22 @@ pub struct EditWebhookRequest {
     pub txn_status: TransactionStatus,
     #[serde(default)]
     pub encoding: AccountWebhookEncoding,
+}
+
+pub struct SmartTransactionConfig<'a> {
+    pub instructions: Vec<Instruction>,
+    pub from_keypair: &'a Keypair,
+    pub skip_preflight_checks: Option<bool>,
+    pub max_retries: Option<usize>,
+}
+
+impl<'a> SmartTransactionConfig<'a> {
+    pub fn new(instructions: Vec<Instruction>, from_keypair: &'a Keypair) -> Self {
+        Self {
+            instructions,
+            from_keypair,
+            skip_preflight_checks: None,
+            max_retries: None,
+        }
+    }
 }

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -778,6 +778,7 @@ pub struct GetPriorityFeeEstimateOptions {
     pub transaction_encoding: Option<UiTransactionEncoding>,
     pub lookback_slots: Option<u8>,
     pub recommended: Option<bool>,
+    pub include_vote: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default)]

--- a/tests/rpc/test_get_priority_fee_estimate.rs
+++ b/tests/rpc/test_get_priority_fee_estimate.rs
@@ -63,6 +63,7 @@ async fn test_get_nft_editions_success() {
             transaction_encoding: None,
             lookback_slots: None,
             recommended: None,
+            include_vote: None,
         }),
     };
 
@@ -117,6 +118,7 @@ async fn test_get_nft_editions_failure() {
             transaction_encoding: None,
             lookback_slots: None,
             recommended: None,
+            include_vote: None,
         }),
     };
 


### PR DESCRIPTION
This PR aims to add a `send_smart_transaction` method, which builds and sends an optimized transaction. It also adds the `get_compute_units` and `poll_transaction_confirmation` methods and new error types. Finally, it adds the new `include_vote` parameter to `GetPriorityFeeEstimateOptions`