### PR TITLE
fix(search_assets): Surface `show_native_balance` and Fix `SerdeJson` Error 

### DIFF
--- a/src/types/options.rs
+++ b/src/types/options.rs
@@ -47,4 +47,6 @@ pub struct SearchAssetsOptions {
     pub show_zero_balance: bool,
     #[serde(default)]
     pub show_closed_accounts: bool,
+    #[serde(default)]
+    pub show_native_balance: bool,
 }

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -572,8 +572,8 @@ pub struct FileQuality {
 pub struct Metadata {
     pub attributes: Option<Vec<Attribute>>,
     pub description: Option<String>,
-    pub name: String,
-    pub symbol: String,
+    pub name: Option<String>,
+    pub symbol: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/tests/rpc/test_get_asset.rs
+++ b/tests/rpc/test_get_asset.rs
@@ -61,8 +61,8 @@ async fn test_get_asset_success() {
                             description: Some(
                                 "Apt323 the 36 page Collectors Edition.".to_string(),
                             ),
-                            name: "Apt323 Collectors Edition #72".to_string(),
-                            symbol: "".to_string(),
+                            name: Some("Apt323 Collectors Edition #72".to_string()),
+                            symbol: Some("".to_string()),
                         },
                         links: Some(
                             Links {

--- a/tests/rpc/test_get_asset_batch.rs
+++ b/tests/rpc/test_get_asset_batch.rs
@@ -47,8 +47,8 @@ async fn test_get_asset_batch_success() {
                             }
                         ]),
                         description: Some("A hotspot NFT on Helium".to_string()),
-                        name: "gentle-mandarin-ferret".to_string(),
-                        symbol: "HOTSPOT".to_string(),
+                        name: Some("gentle-mandarin-ferret".to_string()),
+                        symbol: Some("HOTSPOT".to_string()),
                     },
                     links: Some(Links {
                         external_url: None,
@@ -156,8 +156,8 @@ async fn test_get_asset_batch_success() {
                             }
                         ]),
                         description: Some("Aerial photograph of a parking structure in LA depicting the photographer, Andrew Mason, \"sliding\" through the image.".to_string()),
-                        name: "Slide".to_string(),
-                        symbol: "".to_string(),
+                        name: Some("Slide".to_string()),
+                        symbol: Some("".to_string()),
                     },
                     links: Some(Links {
                         external_url: Some("".to_string()),

--- a/tests/rpc/test_get_assets_by_authority.rs
+++ b/tests/rpc/test_get_assets_by_authority.rs
@@ -100,8 +100,8 @@ async fn test_get_assets_by_authority_success() {
                                 description: Some(
                                     "Fock it.".to_string(),
                                 ),
-                                name: "Mad Lads #6867".to_string(),
-                                symbol: "MAD".to_string(),
+                                name: Some("Mad Lads #6867".to_string()),
+                                symbol: Some("MAD".to_string()),
                             },
                             links: Some(
                                 Links {

--- a/tests/rpc/test_get_assets_by_creator.rs
+++ b/tests/rpc/test_get_assets_by_creator.rs
@@ -100,8 +100,8 @@ async fn test_get_assets_by_creator_success() {
                         description: Some(
                             "Fock it.".to_string(),
                         ),
-                        name: "Mad Lads #6867".to_string(),
-                        symbol: "MAD".to_string(),
+                        name: Some("Mad Lads #6867".to_string()),
+                        symbol: Some("MAD".to_string()),
                     },
                     links: Some(
                         Links {

--- a/tests/rpc/test_get_assets_by_group.rs
+++ b/tests/rpc/test_get_assets_by_group.rs
@@ -51,8 +51,8 @@ async fn test_get_assets_by_group_success() {
                                 trait_type: "Affiliation".to_string(),
                             }]),
                             description: Some("Obi-Wan Kenobi was a legendary Force-sensitive human male Jedi Master who served on the Jedi High Council during the final years of the Republic Era".to_string()),
-                            name: "Obi-Wan Kenobi".to_string(),
-                            symbol:"Guiding Light".to_string(),
+                            name: Some("Obi-Wan Kenobi".to_string()),
+                            symbol: Some("Guiding Light".to_string()),
                         },
                         links: Some(Links {
                             external_url: Some("https://example.com".to_string()),
@@ -169,7 +169,7 @@ async fn test_get_assets_by_group_success() {
 
     let asset: AssetList = response.unwrap();
     assert_eq!(asset.total, 1);
-    assert_eq!(asset.items[0].content.as_ref().unwrap().metadata.name, "Obi-Wan Kenobi");
+    assert_eq!(asset.items[0].content.as_ref().unwrap().metadata.name, Some("Obi-Wan Kenobi".to_string()));
 }
 
 #[tokio::test]

--- a/tests/rpc/test_get_assets_by_group.rs
+++ b/tests/rpc/test_get_assets_by_group.rs
@@ -169,7 +169,10 @@ async fn test_get_assets_by_group_success() {
 
     let asset: AssetList = response.unwrap();
     assert_eq!(asset.total, 1);
-    assert_eq!(asset.items[0].content.as_ref().unwrap().metadata.name, Some("Obi-Wan Kenobi".to_string()));
+    assert_eq!(
+        asset.items[0].content.as_ref().unwrap().metadata.name,
+        Some("Obi-Wan Kenobi".to_string())
+    );
 }
 
 #[tokio::test]

--- a/tests/rpc/test_get_assets_by_owner.rs
+++ b/tests/rpc/test_get_assets_by_owner.rs
@@ -67,8 +67,8 @@ async fn test_get_assets_by_owner_success() {
                             "Visit the domain shown in the picture and claim your exclusive voucher 3000jup.com"
                                 .to_string(),
                         ),
-                        name: "3000Jup For You 3000Jup.com".to_string(),
-                        symbol: "JFY".to_string(),
+                        name: Some("3000Jup For You 3000Jup.com".to_string()),
+                        symbol: Some("JFY".to_string()),
                     },
                     links: Some(Links {
                         external_url: Some("https://3000jup.com".to_string()),

--- a/tests/rpc/test_search_assets.rs
+++ b/tests/rpc/test_search_assets.rs
@@ -67,8 +67,8 @@ async fn test_search_assets_success() {
                             "Visit the domain shown in the picture and claim your exclusive voucher 3000jup.com"
                                 .to_string(),
                         ),
-                        name: "3000Jup For You 3000Jup.com".to_string(),
-                        symbol: "JFY".to_string(),
+                        name: Some("3000Jup For You 3000Jup.com".to_string()),
+                        symbol: Some("JFY".to_string()),
                     },
                     links: Some(Links {
                         external_url: Some("https://3000jup.com".to_string()),


### PR DESCRIPTION
This PR aims to surface the `show_native_balance` option for search asset calls, as well as fix a `SerdeJson` error that would be thrown if an asset's name and symbol are not specified in the `Metadata`