### PR TITLE
feat(client): Add an Async Solana Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ The SDK also comes equipped with `HeliusFactory`, a factory for creating instanc
 ### Embedded Solana Client
 The `Helius` client has an embedded [Solana client](https://docs.rs/solana-client/latest/solana_client/rpc_client/struct.RpcClient.html) that can be accessed via `helius.connection().request_name()` where `request_name()` is a given [RPC method](https://docs.rs/solana-client/latest/solana_client/rpc_client/struct.RpcClient.html#implementations). A full list of all Solana RPC HTTP methods can be found [here](https://solana.com/docs/rpc/http).
 
+Note that this Solana client is synchronous by default. An asynchronous client can be created using the `new_with_async_solana` in place of the `new` method. The asynchronous client can be accessed via `helius.async_connection()?.some_async_method().await?` where `some_async_method()` is a given async RPC method.
+
 ### Examples
 More examples of how to use the SDK can be found in the [`examples`](https://github.com/helius-labs/helius-rust-sdk/tree/dev/examples) directory.
 

--- a/examples/get_latest_blockhash_async.rs
+++ b/examples/get_latest_blockhash_async.rs
@@ -1,0 +1,18 @@
+use helius::error::Result;
+use helius::types::*;
+use helius::Helius;
+
+use solana_sdk::hash::Hash;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let api_key: &str = "your_api_key";
+    let cluster: Cluster = Cluster::MainnetBeta;
+
+    let helius: Helius = Helius::new_with_async_solana(api_key, cluster).expect("Failed to create a Helius client");
+
+    let latest_blockhash: Hash = helius.async_connection()?.get_latest_blockhash().await?;
+    println!("{:?}", latest_blockhash);
+
+    Ok(())
+}

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,7 @@ impl Helius {
     /// Creates a new instance of `Helius` configured with a specific API key and a target cluster
     ///
     /// # Arguments
-    /// * `api_key` - The API key required for authenticating requests made
+    /// * `api_key` - The API key required for authenticating the requests made
     /// * `cluster` - The Solana cluster (Devnet or MainnetBeta) that defines the given network environment
     ///
     /// # Returns
@@ -52,6 +52,26 @@ impl Helius {
             rpc_client,
             async_rpc_client: None,
         })
+    }
+
+    /// Creates a new instance of `Helius` with an asynchronous Solana client
+    /// 
+    /// # Arguments
+    /// * `api_key` - The API key required for authenticating the requests made
+    /// * `cluster` - The Solana cluster (Devnet or MainnetBeta) that defines the given network environment
+    /// 
+    /// # Returns
+    /// An instance of `Helius` if successful. A `HeliusError` is returned if an error occurs during configuration or initialization of the HTTP or RPC client
+    /// 
+    /// # Example
+    /// ```rust
+    /// use helius::Helius;
+    /// use helius::types::Cluster;
+    /// 
+    /// let helius = Helius::new_with_async_solana("your_api_key", Cluster::Devnet).expect("Failed to create a Helius client");
+    /// ```
+    pub fn new_with_async_solana(api_key: &str, cluster: Cluster) -> Result<Self> {
+        
     }
 
     /// Provides a thread-safe way to access RPC functionalities

--- a/src/client.rs
+++ b/src/client.rs
@@ -100,7 +100,8 @@ impl Helius {
         match &self.async_rpc_client {
             Some(client) => Ok(HeliusAsyncSolanaClient::new(client.clone())),
             None => Err(HeliusError::ClientNotInitialized {
-                text: "An asynchronous Solana RPC client is not initialized".to_string(),
+                text: "An asynchronous Solana RPC client must be initialized before trying to access async_connection"
+                    .to_string(),
             }),
         }
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -92,6 +92,10 @@ impl Helius {
         self.rpc_client.clone()
     }
 
+    /// Provides a thread-safe way to access asynchronous Solana client functionalities
+    ///
+    /// # Returns
+    /// A `Result` containing a `HeliusAsyncSolanaClient` if an `async_rpc_client` exists, otherwise a `HeliusError`
     pub fn async_connection(&self) -> Result<HeliusAsyncSolanaClient> {
         match &self.async_rpc_client {
             Some(client) => Ok(HeliusAsyncSolanaClient::new(client.clone())),
@@ -101,16 +105,28 @@ impl Helius {
         }
     }
 
+    /// Provides a thread-safe way to access synchronous Solana client functionalities
+    ///
+    /// # Returns
+    /// A cloned `Arc<SolanaRpcClient>` that can be safely shared across threads
     pub fn connection(&self) -> Arc<SolanaRpcClient> {
         self.rpc_client.solana_client.clone()
     }
 }
 
+/// A wrapper around the asynchronous Solana RPC client that provides thread-safe access
 pub struct HeliusAsyncSolanaClient {
     client: Arc<AsyncSolanaRpcClient>,
 }
 
 impl HeliusAsyncSolanaClient {
+    /// Creates a new instance of `HeliusAsyncSolanaClient`
+    ///
+    /// # Arguments
+    /// * `client` - The asynchronous Solana RPC client to wrap
+    ///
+    /// # Returns
+    /// An instance of `HeliusAsyncSolanaClient`
     pub fn new(client: Arc<AsyncSolanaRpcClient>) -> Self {
         Self { client }
     }
@@ -119,6 +135,7 @@ impl HeliusAsyncSolanaClient {
 impl Deref for HeliusAsyncSolanaClient {
     type Target = AsyncSolanaRpcClient;
 
+    /// Dereferences the wrapper to provide access to the underlying asynchronous Solana RPC client
     fn deref(&self) -> &Self::Target {
         &self.client
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,6 +7,7 @@ use crate::types::Cluster;
 
 use reqwest::Client;
 use solana_client::rpc_client::RpcClient as SolanaRpcClient;
+use solana_client::nonblocking::rpc_client::RpcClient as AsyncSolanaRpcClient;
 
 /// The `Helius` struct is the main entry point to interacting with the SDK
 ///
@@ -19,6 +20,8 @@ pub struct Helius {
     pub client: Client,
     /// A reference-counted RPC client tailored for making requests in a thread-safe manner
     pub rpc_client: Arc<RpcClient>,
+    /// An optional asynchronous Solana client for async operations
+    pub async_rpc_client: Option<Arc<AsyncSolanaRpcClient>>,
 }
 
 impl Helius {
@@ -47,6 +50,7 @@ impl Helius {
             config,
             client,
             rpc_client,
+            async_rpc_client: None,
         })
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -24,6 +24,12 @@ pub enum HeliusError {
     #[error("Solana client error: {0}")]
     ClientError(#[from] ClientError),
 
+    /// Indicates if a client is not already initialized
+    ///
+    /// Useful for the new_with_async_solana method on the `Helius` client
+    #[error("Client not initialized: {text}")]
+    ClientNotInitialized { text: String },
+
     /// Represents compile errors from the Solana SDK
     ///
     /// This captures all compile errors thrown by the Solana SDK

--- a/src/factory.rs
+++ b/src/factory.rs
@@ -89,6 +89,7 @@ impl HeliusFactory {
             config,
             client,
             rpc_client,
+            async_rpc_client: None,
         })
     }
 }

--- a/tests/rpc/test_get_asset.rs
+++ b/tests/rpc/test_get_asset.rs
@@ -173,6 +173,7 @@ async fn test_get_asset_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetAsset = GetAsset {
@@ -228,6 +229,7 @@ async fn test_get_asset_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetAsset = GetAsset {

--- a/tests/rpc/test_get_asset_batch.rs
+++ b/tests/rpc/test_get_asset_batch.rs
@@ -266,6 +266,7 @@ async fn test_get_asset_batch_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetAssetBatch = GetAssetBatch {
@@ -313,6 +314,7 @@ async fn test_get_asset_batch_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetAssetBatch = GetAssetBatch {

--- a/tests/rpc/test_get_asset_proof.rs
+++ b/tests/rpc/test_get_asset_proof.rs
@@ -63,6 +63,7 @@ async fn test_get_asset_proof_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetAssetProof = GetAssetProof {
@@ -110,6 +111,7 @@ async fn test_get_asset_proof_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetAssetProof = GetAssetProof {

--- a/tests/rpc/test_get_asset_proof_batch.rs
+++ b/tests/rpc/test_get_asset_proof_batch.rs
@@ -66,6 +66,7 @@ async fn test_get_asset_proof_batch_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetAssetProofBatch = GetAssetProofBatch {
@@ -121,6 +122,7 @@ async fn test_get_asset_proof_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetAssetProofBatch = GetAssetProofBatch {

--- a/tests/rpc/test_get_assets_by_authority.rs
+++ b/tests/rpc/test_get_assets_by_authority.rs
@@ -230,6 +230,7 @@ async fn test_get_assets_by_authority_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetAssetsByAuthority = GetAssetsByAuthority {
@@ -275,6 +276,7 @@ async fn test_get_assets_by_authority_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetAssetsByAuthority = GetAssetsByAuthority {

--- a/tests/rpc/test_get_assets_by_creator.rs
+++ b/tests/rpc/test_get_assets_by_creator.rs
@@ -230,6 +230,7 @@ async fn test_get_assets_by_creator_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetAssetsByCreator = GetAssetsByCreator {
@@ -275,6 +276,7 @@ async fn test_get_assets_by_creator_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetAssetsByCreator = GetAssetsByCreator {

--- a/tests/rpc/test_get_assets_by_group.rs
+++ b/tests/rpc/test_get_assets_by_group.rs
@@ -145,6 +145,7 @@ async fn test_get_assets_by_group_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let sorting: AssetSorting = AssetSorting {
@@ -203,6 +204,7 @@ async fn test_get_assets_by_group_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let sorting: AssetSorting = AssetSorting {

--- a/tests/rpc/test_get_assets_by_owner.rs
+++ b/tests/rpc/test_get_assets_by_owner.rs
@@ -160,6 +160,7 @@ async fn test_get_assets_by_owner_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetAssetsByOwner = GetAssetsByOwner {
@@ -209,6 +210,7 @@ async fn test_get_assets_by_owner_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetAssetsByOwner = GetAssetsByOwner {

--- a/tests/rpc/test_get_nft_editions.rs
+++ b/tests/rpc/test_get_nft_editions.rs
@@ -54,9 +54,10 @@ async fn test_get_nft_editions_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
-    let request = GetNftEditions {
+    let request: GetNftEditions = GetNftEditions {
         mint: Some("Ey2Qb8kLctbchQsMnhZs5DjY32To2QtPuXNwWvk4NosL".to_string()),
         page: Some(1),
         limit: Some(1),
@@ -105,6 +106,7 @@ async fn test_get_nft_editions_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request = GetNftEditions {

--- a/tests/rpc/test_get_priority_fee_estimate.rs
+++ b/tests/rpc/test_get_priority_fee_estimate.rs
@@ -52,6 +52,7 @@ async fn test_get_nft_editions_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetPriorityFeeEstimateRequest = GetPriorityFeeEstimateRequest {
@@ -107,6 +108,7 @@ async fn test_get_nft_editions_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetPriorityFeeEstimateRequest = GetPriorityFeeEstimateRequest {

--- a/tests/rpc/test_get_rwa_asset.rs
+++ b/tests/rpc/test_get_rwa_asset.rs
@@ -61,6 +61,7 @@ async fn test_get_rwa_asset_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetRwaAssetRequest = GetRwaAssetRequest {
@@ -102,6 +103,7 @@ async fn test_get_rwa_asset_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetRwaAssetRequest = GetRwaAssetRequest {

--- a/tests/rpc/test_get_signatures_for_asset.rs
+++ b/tests/rpc/test_get_signatures_for_asset.rs
@@ -52,6 +52,7 @@ async fn test_get_asset_signatures_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetAssetSignatures = GetAssetSignatures {
@@ -100,6 +101,7 @@ async fn test_get_asset_signatures_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetAssetSignatures = GetAssetSignatures {

--- a/tests/rpc/test_get_token_accounts.rs
+++ b/tests/rpc/test_get_token_accounts.rs
@@ -59,6 +59,7 @@ async fn test_get_token_accounts_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: GetTokenAccounts = GetTokenAccounts {
@@ -110,6 +111,7 @@ async fn test_get_token_accounts_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request = GetTokenAccounts {

--- a/tests/rpc/test_search_assets.rs
+++ b/tests/rpc/test_search_assets.rs
@@ -160,6 +160,7 @@ async fn test_search_assets_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: SearchAssets = SearchAssets {
@@ -206,6 +207,7 @@ async fn test_search_assets_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: SearchAssets = SearchAssets {

--- a/tests/test_client.rs
+++ b/tests/test_client.rs
@@ -13,3 +13,16 @@ fn test_creating_new_client_success() {
     let helius: Helius = result.unwrap();
     assert_eq!(helius.config.api_key, api_key);
 }
+
+#[test]
+fn test_creating_new_async_client_success() {
+    let api_key: &str = "valid-api-key";
+    let cluster: Cluster = Cluster::Devnet;
+
+    let result: Result<Helius> = Helius::new_with_async_solana(api_key, cluster);
+    assert!(result.is_ok());
+
+    let helius: Helius = result.unwrap();
+    assert_eq!(helius.config.api_key, api_key);
+    assert!(helius.async_rpc_client.is_some());
+}

--- a/tests/test_enhanced_transactions.rs
+++ b/tests/test_enhanced_transactions.rs
@@ -79,6 +79,7 @@ async fn test_parse_transactions_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request = ParseTransactionsRequest {
@@ -117,6 +118,7 @@ async fn test_parse_transactions_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
     let request = ParseTransactionsRequest {
         transactions: vec![
@@ -205,6 +207,7 @@ async fn test_parse_transaction_history_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request = ParsedTransactionHistoryRequest {
@@ -242,6 +245,7 @@ async fn test_parse_transaction_history_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
     let request = ParsedTransactionHistoryRequest {
         address: "46tC8n6GyWvUjFxpTE9juG5WZ72RXADpPhY4S1d6wvTi".to_string(),

--- a/tests/test_mint_api.rs
+++ b/tests/test_mint_api.rs
@@ -48,6 +48,7 @@ async fn test_mint_compressed_nft() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: MintCompressedNftRequest = MintCompressedNftRequest {
@@ -121,6 +122,7 @@ async fn test_get_asset_proof_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request: MintCompressedNftRequest = MintCompressedNftRequest {

--- a/tests/webhook/test_append_addresses_to_webhook.rs
+++ b/tests/webhook/test_append_addresses_to_webhook.rs
@@ -63,6 +63,7 @@ async fn test_append_addresses_to_webhook_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let response = helius
@@ -129,6 +130,7 @@ async fn test_append_addresses_to_webhook_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
     let response: Result<Webhook, HeliusError> = helius
         .append_addresses_to_webhook(

--- a/tests/webhook/test_create_webhook.rs
+++ b/tests/webhook/test_create_webhook.rs
@@ -46,6 +46,7 @@ async fn test_create_webhook_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request = CreateWebhookRequest {
@@ -101,6 +102,7 @@ async fn test_create_webhook_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
     let response: Result<Webhook, HeliusError> = helius.create_webhook(request).await;
     assert!(response.is_err(), "Expected an error due to server failure");

--- a/tests/webhook/test_delete_webhook.rs
+++ b/tests/webhook/test_delete_webhook.rs
@@ -32,6 +32,7 @@ async fn test_delete_webhook_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let response = helius.delete_webhook("0e8250a1-ceec-4757-ad69").await;
@@ -65,6 +66,7 @@ async fn test_delete_webhook_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
     let response = helius.delete_webhook("0e8250a1-ceec-4757-ad69").await;
     assert!(response.is_err(), "Expected an error due to server failure");

--- a/tests/webhook/test_edit_webhook.rs
+++ b/tests/webhook/test_edit_webhook.rs
@@ -46,6 +46,7 @@ async fn test_edit_webhook_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let request = EditWebhookRequest {
@@ -109,6 +110,7 @@ async fn test_edit_webhook_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
     let response: Result<Webhook, HeliusError> = helius.edit_webhook(request).await;
     assert!(response.is_err(), "Expected an error due to server failure");

--- a/tests/webhook/test_get_all_webhooks.rs
+++ b/tests/webhook/test_get_all_webhooks.rs
@@ -44,6 +44,7 @@ async fn test_get_all_webhooks_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let response = helius.get_all_webhooks().await;
@@ -85,6 +86,7 @@ async fn test_get_all_webhooks_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
     let response: Result<Vec<Webhook>, HeliusError> = helius.get_all_webhooks().await;
     assert!(response.is_err(), "Expected an error due to server failure");

--- a/tests/webhook/test_get_webhook_by_id.rs
+++ b/tests/webhook/test_get_webhook_by_id.rs
@@ -45,6 +45,7 @@ async fn test_get_webhook_by_id_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let response = helius.get_webhook_by_id("0e8250a1-ceec-4757-ad69").await;
@@ -85,6 +86,7 @@ async fn test_get_webhook_by_id_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
     let response: Result<Webhook, HeliusError> = helius.get_webhook_by_id("0e8250a1-ceec-4757-ad69").await;
     assert!(response.is_err(), "Expected an error due to server failure");

--- a/tests/webhook/test_remove_addresses_from_webhook.rs
+++ b/tests/webhook/test_remove_addresses_from_webhook.rs
@@ -67,6 +67,7 @@ async fn test_remove_addresses_from_webhook_success() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
 
     let response = helius
@@ -140,6 +141,7 @@ async fn test_remove_addresses_from_webhook_failure() {
         config,
         client,
         rpc_client,
+        async_rpc_client: None,
     };
     let response: Result<Webhook, HeliusError> = helius
         .remove_addresses_from_webhook(


### PR DESCRIPTION
This PR addresses the fact that the current embedded Solana client is synchronous, while the rest of the SDK is meant for asynchronous use. To avoid breaking changes, a `new_with_async_solana` method was added to the `Helius` client so users can generate an async Solana client.

In the future, we should consider making the SDK default to an asynchronous embedded Solana client. However, this is sufficient for now