### PR TITLE
fix(optimized_transaction): Fix Retry Logic For `send_smart_transaction`

### DIFF
--- a/src/optimized_transaction.rs
+++ b/src/optimized_transaction.rs
@@ -308,7 +308,15 @@ impl Helius {
             };
 
             match result {
-                Ok(signature) => return self.poll_transaction_confirmation(signature).await,
+                Ok(signature) => {
+                    // Poll for transaction confirmation
+                    match self.poll_transaction_confirmation(signature).await {
+                        Ok(sig) => return Ok(sig),
+                        // Retry on polling failure
+                        Err(_) => continue,
+                    }
+                },
+                // Retry on send failure
                 Err(_) => continue,
             }
         }


### PR DESCRIPTION
This PR aims to address the fact that the `send_smart_transaction` method returns early before retrying after initially polling the transaction's confirmation status