### PR TITLE
fix(types): `TransferFeeConfig` + Formatting

### DIFF
--- a/src/optimized_transaction.rs
+++ b/src/optimized_transaction.rs
@@ -315,7 +315,7 @@ impl Helius {
                         // Retry on polling failure
                         Err(_) => continue,
                     }
-                },
+                }
                 // Retry on send failure
                 Err(_) => continue,
             }

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -411,7 +411,7 @@ pub struct TransferFeeConfig {
     pub withdraw_withheld_authority: String,
     pub withheld_amount: i32,
     pub older_transfer_fee: OlderTransferFee,
-    pub new_trasfer_fee: NewTransferFee,
+    pub new_trasnfer_fee: NewTransferFee,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -411,7 +411,7 @@ pub struct TransferFeeConfig {
     pub withdraw_withheld_authority: String,
     pub withheld_amount: i32,
     pub older_transfer_fee: OlderTransferFee,
-    pub new_trasnfer_fee: NewTransferFee,
+    pub new_transfer_fee: NewTransferFee,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
The goal of this PR is twofold:
- Fix the spelling for `TransferFeeConfig`'s `new_transfer_fee` field
- Formatting