### PR TITLE
fix(workflows): Clean Up Disk Space and Use Artifacts

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -51,6 +51,14 @@ jobs:
     
     - name: Install Protobuf Compiler
       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+    
+    - name: Clean up disk space
+      run: |
+        sudo apt-get clean
+        sudo rm -rf /var/lib/apt/lists/*
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /opt/ghc
       
     - name: Check formatting
       run: cargo fmt --all -- --check
@@ -63,6 +71,16 @@ jobs:
       
     - name: Build
       run: cargo build --verbose
+    
+    - name: Save build artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: build
+        path: target
       
     - name: Run tests
       run: cargo test --verbose
+    
+    - name: Clean up target directory after build
+      if: success()
+      run: rm -rf target

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -80,6 +80,4 @@ jobs:
       
     - name: Run tests
       run: cargo test --verbose
-    
-    - name: Clean up target directory after build
-      run: rm -rf target
+      

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,6 +81,27 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
     
+    - name: Post Cache target directory
+      if: always()
+      uses: actions/cache@v3
+      with:
+          path: target
+          key: ${{ runner.os }}-target-${{ hashFiles('**/Cargo.lock') }}
+
+    - name: Post Cache cargo registry
+      if: always()
+      uses: actions/cache@v3
+      with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+    
+    - name: Post Cache cargo index
+      if: always()
+      uses: actions/cache@v3
+      with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+
     - name: Clean up target directory after build
-      if: success()
+      if: always()
       run: rm -rf target

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -81,27 +81,5 @@ jobs:
     - name: Run tests
       run: cargo test --verbose
     
-    - name: Post Cache target directory
-      if: always()
-      uses: actions/cache@v3
-      with:
-          path: target
-          key: ${{ runner.os }}-target-${{ hashFiles('**/Cargo.lock') }}
-
-    - name: Post Cache cargo registry
-      if: always()
-      uses: actions/cache@v3
-      with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-    
-    - name: Post Cache cargo index
-      if: always()
-      uses: actions/cache@v3
-      with:
-          path: ~/.cargo/git
-          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-
     - name: Clean up target directory after build
-      if: always()
       run: rm -rf target


### PR DESCRIPTION
This PR aims to address the issue recently where checks have been failing because we run out of disk space on the GitHub Actions runner. This PR modifies the workflow to include cleanup steps and use artifacts so we don't have to constantly rebuild from scratch