### PR TITLE
fix(request_handler) to read error message from error json body

### DIFF
--- a/src/request_handler.rs
+++ b/src/request_handler.rs
@@ -3,6 +3,7 @@ use reqwest::{Client, Method, RequestBuilder, Response, StatusCode, Url};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::sync::Arc;
+use serde_json::Value;
 
 /// Manages HTTP requests for the `Helius` client
 ///
@@ -100,10 +101,18 @@ impl RequestHandler {
                 }
             }
         } else {
-            let body_json: serde_json::Result<serde_json::Value> = serde_json::from_str(&body_text);
+            let body_json: serde_json::Result<Value> = serde_json::from_str(&body_text);
             match body_json {
                 Ok(body) => {
-                    let error_message: String = body["error"].as_str().unwrap_or("Unknown error").to_string();
+                    let error_message = match body["error"].clone() {
+                        Value::Object(error_value) => {
+                            error_value.into_iter().map(|(k, v)| format!("{}: {}", k, v)).collect::<Vec<String>>().join(", ").to_string()
+                        }
+                        Value::String(error_value) => {
+                            error_value
+                        }
+                        _ => "Unknown error".to_string(),
+                    };
                     Err(HeliusError::from_response_status(status, path, error_message))
                 }
                 Err(_) => Err(HeliusError::from_response_status(status, path, body_text)),

--- a/src/request_handler.rs
+++ b/src/request_handler.rs
@@ -103,7 +103,7 @@ impl RequestHandler {
             let body_json: serde_json::Result<serde_json::Value> = serde_json::from_str(&body_text);
             match body_json {
                 Ok(body) => {
-                    let error_message: String = body["message"].as_str().unwrap_or("Unknown error").to_string();
+                    let error_message: String = body["error"].as_str().unwrap_or("Unknown error").to_string();
                     Err(HeliusError::from_response_status(status, path, error_message))
                 }
                 Err(_) => Err(HeliusError::from_response_status(status, path, body_text)),

--- a/tests/test_request_handler.rs
+++ b/tests/test_request_handler.rs
@@ -45,7 +45,7 @@ async fn test_bad_request_error() {
         .mock("GET", "/")
         .with_status(400)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"message": "bad request"}"#)
+        .with_body(r#"{"error": "bad request"}"#)
         .create();
 
     let client: Arc<Client> = Arc::new(Client::new());
@@ -58,6 +58,45 @@ async fn test_bad_request_error() {
     assert!(response.is_err());
     match response {
         Err(HeliusError::BadRequest { text, .. }) => assert_eq!(text, "bad request"),
+        _ => panic!("Expected BadRequest error"),
+    }
+
+    server.reset();
+}
+
+#[tokio::test]
+async fn test_bad_request_with_json_rpc_error() {
+    let mut server: Server = Server::new_with_opts_async(mockito::ServerOpts::default()).await;
+    let url: String = server.url();
+
+    server
+        .mock("GET", "/")
+        .with_status(400)
+        .with_header("content-type", "application/json")
+        .with_body(r#"
+        {
+            "jsonrpc": "2.0",
+            "error": {
+                "code": -32603,
+                "message": "internal error: please contact Helius support if this persists"
+            }
+        }"#)
+        .create();
+
+    let client: Arc<Client> = Arc::new(Client::new());
+    let handler: RequestHandler = RequestHandler::new(client).unwrap();
+
+    let response: Result<MockResponse> = handler
+        .send::<(), MockResponse>(Method::GET, url.parse().unwrap(), None)
+        .await;
+
+    assert!(response.is_err());
+    match response {
+        Err(HeliusError::BadRequest { text, .. }) =>
+            assert_eq!(
+                text,
+                "code: -32603, message: \"internal error: please contact Helius support if this persists\""
+            ),
         _ => panic!("Expected BadRequest error"),
     }
 


### PR DESCRIPTION
Getting the error message description text from a 400 response is not working. I'm seeing `Unknown error` returned every time it fails for me.

While I haven't actually tested this. I'm pretty sure it should be getting the `error` value here not `message`, refer screen shot:

<img width="1281" alt="Screenshot 2024-06-19 at 11 18 50 PM" src="https://github.com/helius-labs/helius-rust-sdk/assets/4157455/99c7a642-bdbb-49f0-b4c7-60bb89a80aa2">

another example 400 response:
`"{"error":"reached webhook limit"}"`

#### edit:

So this error format above seems to only be returned by the post webhook api.

For other apis errors are returned in this format:

```
{
    "jsonrpc": "2.0",
    "error": {
        "code": -32603,
        "message": "internal error: please contact Helius support if this persists"
    }
}
```

Which is where I think getting `message` came from (still incorrect though as it would need to be accessed by `error.message`)
