### PR TITLE
fix(types): mismatch

### DIFF
--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -795,7 +795,7 @@ pub struct GetPriorityFeeEstimateRequest {
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct MicroLamportPriorityFeeLevels {
-    pub none: f64,
+    pub min: f64,
     pub low: f64,
     pub medium: f64,
     pub high: f64,


### PR DESCRIPTION
Fixes this issue:
![image](https://github.com/helius-labs/helius-rust-sdk/assets/165314898/aa8d9cc7-c346-4420-b374-c7368f8b76b5)
