### PR TITLE
feat(optimized_transaction): Implement `send_smart_transaction_with_seeds`

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Our SDK is designed to provide a seamless developer experience when building on 
 - [`get_compute_units`](https://github.com/helius-labs/helius-rust-sdk/blob/a79a751e1a064125010bdb359068a366d635d005/src/optimized_transaction.rs#L29-L75) - Simulates a transaction to get the total compute units consumed
 - [`poll_transaction_confirmation`](https://github.com/helius-labs/helius-rust-sdk/blob/a79a751e1a064125010bdb359068a366d635d005/src/optimized_transaction.rs#L77-L112) - Polls a transaction to check whether it has been confirmed in 5 second intervals with a 15 second timeout
 - [`send_smart_transaction`](https://github.com/helius-labs/helius-rust-sdk/blob/705d66fb7d4004fc32c2a5f0d6ca4a1f2a7b175d/src/optimized_transaction.rs#L314-L374) - Builds and sends an optimized transaction, and handles its confirmation status
+- [`send_smart_transaction_with_seeds`]() - Sends a smart transaction using seed bytes
 
 ### Jito Smart Transactions and Helper Methods
 - [`add_tip_instruction`](https://github.com/helius-labs/helius-rust-sdk/blob/02b351a5ee3fe16a36078b40f92dc72d0ad077ed/src/jito.rs#L66-L83) - Adds a tip instruction to the instructions provided

--- a/src/optimized_transaction.rs
+++ b/src/optimized_transaction.rs
@@ -403,7 +403,7 @@ impl Helius {
     ///
     /// This function will return an error if keypair creation from seeds fails, the underlying `send_smart_transaction` call fails,
     /// or no signer seeds are provided
-    /// 
+    ///
     /// # Notes
     ///
     /// If no `fee_payer_seed` is provided, the first signer (i.e., derived from the first seed in `signer_seeds`) will be used as the fee payer
@@ -413,9 +413,11 @@ impl Helius {
         send_options: Option<RpcSendTransactionConfig>,
     ) -> Result<Signature> {
         if create_config.signer_seeds.is_empty() {
-            return Err(HeliusError::InvalidInput("At least one signer seed must be provided".to_string()));
+            return Err(HeliusError::InvalidInput(
+                "At least one signer seed must be provided".to_string(),
+            ));
         }
-        
+
         let mut signers: Vec<Keypair> = create_config
             .signer_seeds
             .into_iter()

--- a/src/optimized_transaction.rs
+++ b/src/optimized_transaction.rs
@@ -424,13 +424,11 @@ impl Helius {
             .map(|seed| keypair_from_seed(&seed).expect("Failed to create keypair from seed"))
             .collect();
 
-        let fee_payer: Option<Keypair> = create_config
-            .fee_payer_seed
-            .map(|seed| keypair_from_seed(&seed).expect("Failed to create fee payer keypair from seed"));
-
         // Determine the fee payer
-        let fee_payer_index: usize = if fee_payer.is_some() {
-            signers.push(fee_payer.unwrap());
+        let fee_payer_index: usize = if let Some(fee_payer_seed) = create_config.fee_payer_seed {
+            let fee_payer: Keypair =
+                keypair_from_seed(&fee_payer_seed).expect("Failed to create fee payer keypair from seed");
+            signers.push(fee_payer);
             signers.len() - 1 // Index of the last signer (fee payer)
         } else {
             0 // Index of the first signer

--- a/src/optimized_transaction.rs
+++ b/src/optimized_transaction.rs
@@ -1,7 +1,7 @@
 use crate::error::{HeliusError, Result};
 use crate::types::{
-    CreateSmartTransactionConfig, GetPriorityFeeEstimateOptions, GetPriorityFeeEstimateRequest,
-    GetPriorityFeeEstimateResponse, SmartTransaction, SmartTransactionConfig,
+    CreateSmartTransactionConfig, CreateSmartTransactionSeedConfig, GetPriorityFeeEstimateOptions,
+    GetPriorityFeeEstimateRequest, GetPriorityFeeEstimateResponse, SmartTransaction, SmartTransactionConfig,
 };
 use crate::Helius;
 
@@ -9,6 +9,7 @@ use bincode::{serialize, ErrorKind};
 use reqwest::StatusCode;
 use solana_client::rpc_config::{RpcSendTransactionConfig, RpcSimulateTransactionConfig};
 use solana_client::rpc_response::{Response, RpcSimulateTransactionResult};
+use solana_sdk::signature::{keypair_from_seed, Keypair};
 use solana_sdk::{
     address_lookup_table::AddressLookupTableAccount,
     bs58::encode,
@@ -377,5 +378,75 @@ impl Helius {
             code: StatusCode::REQUEST_TIMEOUT,
             text: "Transaction failed to confirm in 60s".to_string(),
         })
+    }
+
+    /// Sends a smart transaction using seed bytes
+    ///
+    /// This method allows for sending smart transactions in asynchronous contexts
+    /// where the Signer trait's lack of Send + Sync would otherwise cause issues.
+    /// It creates Keypairs from the provided seed bytes and uses them to sign the transaction.
+    ///
+    /// # Arguments
+    ///
+    /// * `create_config` - A `CreateSmartTransactionSeedConfig` containing:
+    ///   - `instructions`: The instructions to be executed in the transaction.
+    ///   - `signer_seeds`: Seed bytes for generating signer keypairs.
+    ///   - `fee_payer_seed`: Optional seed bytes for generating the fee payer keypair.
+    ///   - `lookup_tables`: Optional address lookup tables for the transaction.
+    /// * `send_options` - Optional `RpcSendTransactionConfig` for sending the transaction.
+    ///
+    /// # Returns
+    ///
+    /// A `Result<Signature>` containing the transaction signature if successful, or an error if not.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if keypair creation from seeds fails or the underlying `send_smart_transaction` call fails
+    /// 
+    /// # Notes
+    ///
+    /// If no `fee_payer_seed` is provided, the first signer (i.e., derived from the first seed in `signer_seeds`) will be used as the fee payer
+    pub async fn send_smart_transaction_with_seeds(
+        &self,
+        create_config: CreateSmartTransactionSeedConfig,
+        send_options: Option<RpcSendTransactionConfig>,
+    ) -> Result<Signature> {
+        if create_config.signer_seeds.is_empty() {
+            return Err(HeliusError::InvalidInput("At least one signer seed must be provided".to_string()));
+        }
+        
+        let mut signers: Vec<Keypair> = create_config
+            .signer_seeds
+            .into_iter()
+            .map(|seed| keypair_from_seed(&seed).expect("Failed to create keypair from seed"))
+            .collect();
+
+        let fee_payer: Option<Keypair> = create_config
+            .fee_payer_seed
+            .map(|seed| keypair_from_seed(&seed).expect("Failed to create fee payer keypair from seed"));
+
+        // Determine the fee payer
+        let fee_payer_index: usize = if fee_payer.is_some() {
+            signers.push(fee_payer.unwrap());
+            signers.len() - 1 // Index of the last signer (fee payer)
+        } else {
+            0 // Index of the first signer
+        };
+
+        let signer_refs: Vec<&dyn Signer> = signers.iter().map(|keypair| keypair as &dyn Signer).collect();
+
+        let create_smart_transaction_config: CreateSmartTransactionConfig<'_> = CreateSmartTransactionConfig {
+            instructions: create_config.instructions,
+            signers: signer_refs,
+            lookup_tables: create_config.lookup_tables,
+            fee_payer: Some(&signers[fee_payer_index] as &dyn Signer),
+        };
+
+        let smart_transaction_config: SmartTransactionConfig<'_> = SmartTransactionConfig {
+            create_config: create_smart_transaction_config,
+            send_options: send_options.unwrap_or_default(),
+        };
+
+        self.send_smart_transaction(smart_transaction_config).await
     }
 }

--- a/src/optimized_transaction.rs
+++ b/src/optimized_transaction.rs
@@ -401,7 +401,8 @@ impl Helius {
     ///
     /// # Errors
     ///
-    /// This function will return an error if keypair creation from seeds fails or the underlying `send_smart_transaction` call fails
+    /// This function will return an error if keypair creation from seeds fails, the underlying `send_smart_transaction` call fails,
+    /// or no signer seeds are provided
     /// 
     /// # Notes
     ///

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -989,3 +989,32 @@ pub struct BasicRequest {
     pub method: String,
     pub params: Vec<Vec<String>>,
 }
+
+#[derive(Clone)]
+pub struct CreateSmartTransactionSeedConfig {
+    pub instructions: Vec<Instruction>,
+    pub signer_seeds: Vec<[u8; 32]>,
+    pub fee_payer_seed: Option<[u8; 32]>,
+    pub lookup_tables: Option<Vec<AddressLookupTableAccount>>,
+}
+
+impl CreateSmartTransactionSeedConfig {
+    pub fn new(instructions: Vec<Instruction>, signer_seeds: Vec<[u8; 32]>) -> Self {
+        Self {
+            instructions,
+            signer_seeds,
+            fee_payer_seed: None,
+            lookup_tables: None,
+        }
+    }
+
+    pub fn with_fee_payer_seed(mut self, seed: [u8; 32]) -> Self {
+        self.fee_payer_seed = Some(seed);
+        self
+    }
+
+    pub fn with_lookup_tables(mut self, lookup_tables: Vec<AddressLookupTableAccount>) -> Self {
+        self.lookup_tables = Some(lookup_tables);
+        self
+    }
+}


### PR DESCRIPTION
This PR aims to add `send_smart_transaction_with_seeds`, which sends a smart transaction using seed bytes. This method would allow for sending smart transactions in async contexts where the `Signer` trait's lack of `Send + Sync` would otherwise cause issues (i.e., the issue outlined in #61)