### PR TITLE
fix: changed api mainnet endpoint

### DIFF
--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -34,11 +34,11 @@ impl HeliusEndpoints {
                 rpc: "https://devnet.helius-rpc.com/".to_string(),
             },
             Cluster::MainnetBeta => HeliusEndpoints {
-                api: "https://api-mainnet.helius-rpc.com/".to_string(),
+                api: "https://api.helius-rpc.com/".to_string(),
                 rpc: "https://mainnet.helius-rpc.com/".to_string(),
             },
             Cluster::StakedMainnetBeta => HeliusEndpoints {
-                api: "https://api-mainnet.helius-rpc.com/".to_string(),
+                api: "https://api.helius-rpc.com/".to_string(),
                 rpc: "https://staked.helius-rpc.com/".to_string(),
             },
         }

--- a/tests/test_factory.rs
+++ b/tests/test_factory.rs
@@ -17,7 +17,7 @@ fn test_factory_create_mainnet_instance() {
     let helius: Helius = factory.create(Cluster::MainnetBeta).unwrap();
 
     assert_eq!(helius.config.api_key, "valid_api_key");
-    assert_eq!(helius.config.endpoints.api, "https://api-mainnet.helius-rpc.com/");
+    assert_eq!(helius.config.endpoints.api, "https://api.helius-rpc.com/");
     assert_eq!(helius.config.endpoints.rpc, "https://mainnet.helius-rpc.com/");
 }
 
@@ -27,7 +27,7 @@ fn test_factory_create_staked_mainnet_instance() {
     let helius: Helius = factory.create(Cluster::StakedMainnetBeta).unwrap();
 
     assert_eq!(helius.config.api_key, "valid_api_key");
-    assert_eq!(helius.config.endpoints.api, "https://api-mainnet.helius-rpc.com/");
+    assert_eq!(helius.config.endpoints.api, "https://api.helius-rpc.com/");
     assert_eq!(helius.config.endpoints.rpc, "https://staked.helius-rpc.com/");
 }
 
@@ -40,6 +40,6 @@ fn test_factory_create_with_reqwest() {
         .unwrap();
 
     assert_eq!(helius.config.api_key, "valid_api_key");
-    assert_eq!(helius.config.endpoints.api, "https://api-mainnet.helius-rpc.com/");
+    assert_eq!(helius.config.endpoints.api, "https://api.helius-rpc.com/");
     assert_eq!(helius.config.endpoints.rpc, "https://mainnet.helius-rpc.com/");
 }


### PR DESCRIPTION
The previous endpoint, `https://api-mainnet.helius-rpc.com/` does not exist. 