### PR TITLE
Add slot to transaction notification

### DIFF
--- a/src/types/enhanced_websocket.rs
+++ b/src/types/enhanced_websocket.rs
@@ -96,4 +96,5 @@ pub struct RpcTransactionsConfig {
 pub struct TransactionNotification {
     pub transaction: EncodedTransactionWithStatusMeta,
     pub signature: String,
+    pub slot: u64,
 }


### PR DESCRIPTION
Hi there!

I realized that on the transactionSubscribe websocket we get the `slot` information. But it's currently not a field of the TransactionNotification struct, so it's not usable in Rust code. Did I miss something, or could this addition be considered?