### PR TITLE
Remove debug print on websocket start

### DIFF
--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -218,7 +218,6 @@ impl EnhancedWebsocket {
                 request_id += 1;
                 let method = format!("{operation}Subscribe");
                 let body = json!({"jsonrpc":"2.0","id":request_id,"method":method,"params":params});
-                println!("subscription: {:#}", body);
                 ws.send(Message::Text(body.to_string())).await?;
                 requests_subscribe.insert(request_id, (operation, response_sender));
               },


### PR DESCRIPTION
Currently, on each start/restart of a WebSocket, we git this print in our logs. This clutters the output quite a bit. I suggest removing or replacing it with something like tracing, where the user can decide how much information he gets.

```
subscription: {
  "id": 1,
  "jsonrpc": "2.0",
  "method": "transactionSubscribe",
  "params": [
    {
      "accountInclude": [
        ""
      ],
      "failed": false,
      "vote": false
    },
    {
      "commitment": "processed",
      "encoding": "jsonParsed",
      "maxSupportedTransactionVersion": 0,
      "showRewards": true,
      "transactionDetails": "full"
    }
  ]
}
```