### PR TITLE
Add `send_and_confirm_transaction` method and refactor transaction sending logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Our SDK is designed to provide a seamless developer experience when building on 
 - [`get_compute_units`](https://github.com/helius-labs/helius-rust-sdk/blob/a79a751e1a064125010bdb359068a366d635d005/src/optimized_transaction.rs#L29-L75) - Simulates a transaction to get the total compute units consumed
 - [`poll_transaction_confirmation`](https://github.com/helius-labs/helius-rust-sdk/blob/a79a751e1a064125010bdb359068a366d635d005/src/optimized_transaction.rs#L77-L112) - Polls a transaction to check whether it has been confirmed in 5 second intervals with a 15 second timeout
 - [`send_smart_transaction`](https://github.com/helius-labs/helius-rust-sdk/blob/705d66fb7d4004fc32c2a5f0d6ca4a1f2a7b175d/src/optimized_transaction.rs#L314-L374) - Builds and sends an optimized transaction, and handles its confirmation status
+- [`send_and_confirm_transaction`] - Sends a transaction and handles its confirmation status with retry logic
 - [`send_smart_transaction_with_seeds`]() - Sends a smart transaction using seed bytes
 
 ### Jito Smart Transactions and Helper Methods


### PR DESCRIPTION
## Description:
This PR introduces a new `send_and_confirm_transaction` method to handle transaction sending and confirmation in a more modular way. It also refactors the existing transaction sending logic in `send_smart_transaction` to use this new method, reducing code duplication and improving maintainability.

## Changes:
- Added new `send_and_confirm_transaction` method that accepts any transaction implementing `SerializableTransaction`
- Added new method documentation to README.md
- Refactored `send_smart_transaction` to use the new method
- Improved code organization by removing duplicate transaction sending logic
- Added `SerializableTransaction` import from solana_client