### PR TITLE
Fix instruction error serialization 0.2.1

### DIFF
--- a/src/types/enhanced_transaction_types.rs
+++ b/src/types/enhanced_transaction_types.rs
@@ -78,7 +78,7 @@ pub struct TokenTransfer {
 #[serde(rename_all = "camelCase")]
 pub struct TransactionError {
     #[serde(rename = "InstructionError")]
-    pub instruciton_error: Option<serde_json::Value>,
+    pub instruction_error: Option<serde_json::Value>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]

--- a/src/types/enhanced_transaction_types.rs
+++ b/src/types/enhanced_transaction_types.rs
@@ -78,7 +78,7 @@ pub struct TokenTransfer {
 #[serde(rename_all = "camelCase")]
 pub struct TransactionError {
     #[serde(rename = "InstructionError")]
-    pub instruciton_error: serde_json::Value,
+    pub instruciton_error: Option<serde_json::Value>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
Fixes

```
Failed to parse transactions for signatures, error: SerdeJson(Error("missing field `InstructionError`", ...))
```

Encountered when calling `helius::Helius.parse_transactions` ala:

```
        match state.helius.parse_transactions(req).await {
            Ok(transactions) => {
                for transaction in transactions {
                    crate::enhanced_transactions::ingest_essentials(&state, transaction).await?;
                }
            }
```