### PR TITLE
feat: Replace lifetimes with Arc for CreateSmartTransactionConfig

### DIFF
--- a/examples/send_smart_transaction_with_tip.rs
+++ b/examples/send_smart_transaction_with_tip.rs
@@ -6,6 +6,7 @@ use solana_sdk::{
     system_instruction::transfer,
 };
 use std::str::FromStr;
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::sleep;
 
@@ -28,7 +29,7 @@ async fn main() {
 
     let create_config: CreateSmartTransactionConfig = CreateSmartTransactionConfig {
         instructions,
-        signers: vec![&from_keypair],
+        signers: vec![Arc::new(from_keypair)],
         lookup_tables: None,
         fee_payer: None,
     };

--- a/src/jito.rs
+++ b/src/jito.rs
@@ -92,7 +92,7 @@ impl Helius {
     /// A `Result` containing the serialized transaction as a base58-encoded string and the last valid block height
     pub async fn create_smart_transaction_with_tip(
         &self,
-        mut config: CreateSmartTransactionConfig<'_>,
+        mut config: CreateSmartTransactionConfig,
         tip_amount: Option<u64>,
     ) -> Result<(String, u64)> {
         if config.signers.is_empty() {
@@ -105,6 +105,7 @@ impl Helius {
         let random_tip_account: &str = *JITO_TIP_ACCOUNTS.choose(&mut rand::thread_rng()).unwrap();
         let payer_key: Pubkey = config
             .fee_payer
+            .as_ref()
             .map_or_else(|| config.signers[0].pubkey(), |signer| signer.pubkey());
 
         self.add_tip_instruction(&mut config.instructions, payer_key, random_tip_account, tip_amount);
@@ -212,7 +213,7 @@ impl Helius {
     /// A `Result` containing the bundle IDc
     pub async fn send_smart_transaction_with_tip(
         &self,
-        config: SmartTransactionConfig<'_>,
+        config: SmartTransactionConfig,
         tip_amount: Option<u64>,
         region: Option<JitoRegion>,
     ) -> Result<String> {

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -6,6 +6,7 @@ use super::{
 use crate::types::{DisplayOptions, GetAssetOptions};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::sync::Arc;
 use std::time::Duration;
 
 use solana_client::rpc_config::RpcSendTransactionConfig;
@@ -950,15 +951,15 @@ pub struct EditWebhookRequest {
     pub encoding: AccountWebhookEncoding,
 }
 
-pub struct CreateSmartTransactionConfig<'a> {
+pub struct CreateSmartTransactionConfig {
     pub instructions: Vec<Instruction>,
-    pub signers: Vec<&'a dyn Signer>,
+    pub signers: Vec<Arc<dyn Signer>>,
     pub lookup_tables: Option<Vec<AddressLookupTableAccount>>,
-    pub fee_payer: Option<&'a dyn Signer>,
+    pub fee_payer: Option<Arc<dyn Signer>>,
 }
 
-impl<'a> CreateSmartTransactionConfig<'a> {
-    pub fn new(instructions: Vec<Instruction>, signers: Vec<&'a dyn Signer>) -> Self {
+impl CreateSmartTransactionConfig {
+    pub fn new(instructions: Vec<Instruction>, signers: Vec<Arc<dyn Signer>>) -> Self {
         Self {
             instructions,
             signers,
@@ -985,14 +986,14 @@ impl Into<Duration> for Timeout {
     }
 }
 
-pub struct SmartTransactionConfig<'a> {
-    pub create_config: CreateSmartTransactionConfig<'a>,
+pub struct SmartTransactionConfig {
+    pub create_config: CreateSmartTransactionConfig,
     pub send_options: RpcSendTransactionConfig,
     pub timeout: Timeout,
 }
 
-impl<'a> SmartTransactionConfig<'a> {
-    pub fn new(instructions: Vec<Instruction>, signers: Vec<&'a dyn Signer>, timeout: Timeout) -> Self {
+impl SmartTransactionConfig {
+    pub fn new(instructions: Vec<Instruction>, signers: Vec<Arc<dyn Signer>>, timeout: Timeout) -> Self {
         Self {
             create_config: CreateSmartTransactionConfig::new(instructions, signers),
             send_options: RpcSendTransactionConfig::default(),


### PR DESCRIPTION
Closes #83 
Wraps into `Arc` variables that were referenced with lifetime in CreateSmartTransactionConfig