### PR TITLE
fix(search_assets): Issue with field deserialization

### DIFF
--- a/src/enhanced_transactions.rs
+++ b/src/enhanced_transactions.rs
@@ -48,6 +48,26 @@ impl Helius {
             url = format!("{}&before={}", url, before);
         }
 
+        if let Some(until) = request.until {
+            url = format!("{}&until={}", url, until);
+        }
+
+        if let Some(commitment) = request.commitment {
+            url = format!("{}&commitment={}", url, commitment);
+        }
+
+        if let Some(source) = request.source {
+            url = format!("{}&source={}", url, source);
+        }
+
+        if let Some(transaction_type) = request.transaction_type {
+            url = format!("{}&type={}", url, transaction_type);
+        }
+
+        if let Some(limit) = request.limit {
+            url = format!("{}&limit={}", url, limit);
+        }
+
         let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
 
         self.rpc_client.handler.send(Method::GET, parsed_url, None::<&()>).await

--- a/src/types/enhanced_transaction_types.rs
+++ b/src/types/enhanced_transaction_types.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Number, Value};
+use solana_sdk::commitment_config::CommitmentLevel;
 
 use super::*;
 use crate::utils::deserialize_str_to_number;
@@ -214,6 +215,14 @@ pub struct ParseTransactionsRequest {
 pub struct ParsedTransactionHistoryRequest {
     pub address: String,
     pub before: Option<String>,
+    pub until: Option<String>,
+    // Only support `finalized` and `confirmed` at this time.
+    pub commitment: Option<CommitmentLevel>,
+    pub source: Option<Source>,
+    #[serde(rename = "type")]
+    pub transaction_type: Option<TransactionType>,
+    // Should be between 1 and 100
+    pub limit: Option<u64>,
 }
 
 /// We have a limit of 100 transactions per call, so this helps split the signatures into different chunks

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -272,6 +272,13 @@ pub struct ApiResponse<T> {
 }
 
 #[derive(Serialize, Deserialize, Debug, Default)]
+pub struct NativeBalance {
+    pub lamports: f32,
+    pub price_per_sol: f32,
+    pub total_price: f32,
+}
+
+#[derive(Serialize, Deserialize, Debug, Default)]
 pub struct AssetList {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub grand_total: Option<u64>,
@@ -286,6 +293,8 @@ pub struct AssetList {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<String>,
     pub items: Vec<Asset>,
+    #[serde(rename = "nativeBalance", skip_serializing_if = "Option::is_none")]
+    pub native_balance: Option<NativeBalance>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub errors: Option<Vec<AssetError>>,
 }

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -273,9 +273,9 @@ pub struct ApiResponse<T> {
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct NativeBalance {
-    pub lamports: f32,
-    pub price_per_sol: f32,
-    pub total_price: f32,
+    pub lamports: u64,
+    pub price_per_sol: f64,
+    pub total_price: f64,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default)]

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -521,7 +521,6 @@ pub struct TokenInfo {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PriceInfo {
-    #[serde(rename = "pricePerToken")]
     pub price_per_token: f32,
     pub currency: String,
 }

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -356,7 +356,6 @@ pub struct Asset {
     pub mutable: bool,
     pub burnt: bool,
     pub mint_extensions: Option<Value>,
-    #[serde(rename = "tokenSupply")]
     pub token_info: Option<TokenInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub group_definition: Option<GroupDefinition>,

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -512,15 +512,10 @@ pub struct TokenInfo {
     pub balance: Option<u64>,
     pub supply: Option<u64>,
     pub decimals: Option<i32>,
-    #[serde(rename = "tokenProgram")]
     pub token_program: Option<String>,
-    #[serde(rename = "associatedTokenAddress")]
     pub associated_token_address: Option<String>,
-    #[serde(rename = "priceInfo")]
     pub price_info: Option<PriceInfo>,
-    #[serde(rename = "mintAuthority")]
     pub mint_authority: Option<String>,
-    #[serde(rename = "freezeAuthority")]
     pub freeze_authority: Option<String>,
 }
 


### PR DESCRIPTION
Within the `Asset` type, there was an incorrect `#[serde(rename = "tokenSupply")]` for the `token_info` field. As is, it always returns `None` because there is no `tokenSupply` field in the response body.
