### PR TITLE
feat(optimized_transaction): Add Priority Fee Cap

### DIFF
--- a/examples/send_smart_transaction_with_tip.rs
+++ b/examples/send_smart_transaction_with_tip.rs
@@ -32,6 +32,7 @@ async fn main() {
         signers: vec![Arc::new(from_keypair)],
         lookup_tables: None,
         fee_payer: None,
+        priority_fee_cap: None,
     };
 
     let config: SmartTransactionConfig = SmartTransactionConfig {

--- a/src/optimized_transaction.rs
+++ b/src/optimized_transaction.rs
@@ -243,7 +243,7 @@ impl Helius {
                 .ok_or(HeliusError::InvalidInput(
                     "Priority fee estimate not available".to_string(),
                 ))? as u64;
-        
+
         let priority_fee: u64 = if let Some(provided_fee) = config.priority_fee_cap {
             // Take the minimum between the estimate and the user-provided cap
             std::cmp::min(priority_fee_recommendation, provided_fee)
@@ -252,8 +252,7 @@ impl Helius {
         };
 
         // Add the compute unit price instruction with the estimated fee
-        let compute_budget_ix: Instruction =
-            ComputeBudgetInstruction::set_compute_unit_price(priority_fee);
+        let compute_budget_ix: Instruction = ComputeBudgetInstruction::set_compute_unit_price(priority_fee);
         let mut updated_instructions: Vec<Instruction> = config.instructions.clone();
         updated_instructions.push(compute_budget_ix.clone());
         final_instructions.push(compute_budget_ix);

--- a/src/optimized_transaction.rs
+++ b/src/optimized_transaction.rs
@@ -243,10 +243,17 @@ impl Helius {
                 .ok_or(HeliusError::InvalidInput(
                     "Priority fee estimate not available".to_string(),
                 ))? as u64;
+        
+        let priority_fee: u64 = if let Some(provided_fee) = config.priority_fee_cap {
+            // Take the minimum between the estimate and the user-provided cap
+            std::cmp::min(priority_fee_recommendation, provided_fee)
+        } else {
+            priority_fee_recommendation
+        };
 
         // Add the compute unit price instruction with the estimated fee
         let compute_budget_ix: Instruction =
-            ComputeBudgetInstruction::set_compute_unit_price(priority_fee_recommendation);
+            ComputeBudgetInstruction::set_compute_unit_price(priority_fee);
         let mut updated_instructions: Vec<Instruction> = config.instructions.clone();
         updated_instructions.push(compute_budget_ix.clone());
         final_instructions.push(compute_budget_ix);
@@ -474,6 +481,7 @@ impl Helius {
             signers,
             lookup_tables: create_config.lookup_tables,
             fee_payer: Some(fee_payer),
+            priority_fee_cap: create_config.priority_fee_cap,
         };
 
         let smart_transaction_config: SmartTransactionConfig = SmartTransactionConfig {

--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -956,6 +956,7 @@ pub struct CreateSmartTransactionConfig {
     pub signers: Vec<Arc<dyn Signer>>,
     pub lookup_tables: Option<Vec<AddressLookupTableAccount>>,
     pub fee_payer: Option<Arc<dyn Signer>>,
+    pub priority_fee_cap: Option<u64>,
 }
 
 impl CreateSmartTransactionConfig {
@@ -965,6 +966,7 @@ impl CreateSmartTransactionConfig {
             signers,
             lookup_tables: None,
             fee_payer: None,
+            priority_fee_cap: None,
         }
     }
 }
@@ -1016,6 +1018,7 @@ pub struct CreateSmartTransactionSeedConfig {
     pub signer_seeds: Vec<[u8; 32]>,
     pub fee_payer_seed: Option<[u8; 32]>,
     pub lookup_tables: Option<Vec<AddressLookupTableAccount>>,
+    pub priority_fee_cap: Option<u64>,
 }
 
 impl CreateSmartTransactionSeedConfig {
@@ -1025,6 +1028,7 @@ impl CreateSmartTransactionSeedConfig {
             signer_seeds,
             fee_payer_seed: None,
             lookup_tables: None,
+            priority_fee_cap: None,
         }
     }
 


### PR DESCRIPTION
This PR allows users to cap the priority fees for a given smart transaction at a specific number and use that as the maximum possible value instead of using what is strictly returned by the Priority Fee API 

Consider the following scenarios where we cap priority fees at 10k:
- If the priority fee estimate based on the serialized transaction is 5k, then we'd use 5k
- If the priority fee estimate based on the serialized transaction is 10k, then we'd use 10k
- If the priority fee estimate based on the serialized transaction is 15k, then we'd use 10k

This also resolves #81
