### PR TITLE
feat(ws): Better Health Checks

### DIFF
--- a/examples/enhanced_websocket_accounts.rs
+++ b/examples/enhanced_websocket_accounts.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<()> {
     let api_key: &str = "your_api_key";
     let cluster: Cluster = Cluster::MainnetBeta;
 
-    let helius: Helius = Helius::new_with_ws_default(api_key, cluster).await?;
+    let helius: Helius = Helius::new_with_ws(api_key, cluster).await?;
 
     let key: pubkey::Pubkey = pubkey!("BtsmiEEvnSuUnKxqXj2PZRYpPJAc7C34mGz8gtJ1DAaH");
 

--- a/examples/enhanced_websocket_accounts.rs
+++ b/examples/enhanced_websocket_accounts.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<()> {
     let api_key: &str = "your_api_key";
     let cluster: Cluster = Cluster::MainnetBeta;
 
-    let helius: Helius = Helius::new_with_ws(api_key, cluster).await?;
+    let helius: Helius = Helius::new_with_ws_default(api_key, cluster).await?;
 
     let key: pubkey::Pubkey = pubkey!("BtsmiEEvnSuUnKxqXj2PZRYpPJAc7C34mGz8gtJ1DAaH");
 

--- a/examples/enhanced_websocket_transactions.rs
+++ b/examples/enhanced_websocket_transactions.rs
@@ -9,7 +9,8 @@ async fn main() -> Result<()> {
     let api_key: &str = "your_api_key";
     let cluster: Cluster = Cluster::MainnetBeta;
 
-    let helius: Helius = Helius::new_with_ws(api_key, cluster).await.unwrap();
+    // Uses custom ping-pong timeouts to ping every 15s and timeout after 45s of no pong
+    let helius: Helius = Helius::new_with_ws(api_key, cluster, Some(15), Some(45)).await.unwrap();
 
     let key: pubkey::Pubkey = pubkey!("BtsmiEEvnSuUnKxqXj2PZRYpPJAc7C34mGz8gtJ1DAaH");
 

--- a/examples/enhanced_websocket_transactions.rs
+++ b/examples/enhanced_websocket_transactions.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<()> {
     let cluster: Cluster = Cluster::MainnetBeta;
 
     // Uses custom ping-pong timeouts to ping every 15s and timeout after 45s of no pong
-    let helius: Helius = Helius::new_with_ws(api_key, cluster, Some(15), Some(45)).await.unwrap();
+    let helius: Helius = Helius::new_with_ws_with_timeouts(api_key, cluster, Some(15), Some(45)).await?;
 
     let key: pubkey::Pubkey = pubkey!("BtsmiEEvnSuUnKxqXj2PZRYpPJAc7C34mGz8gtJ1DAaH");
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -100,7 +100,7 @@ impl Helius {
     ///
     /// # Returns
     /// An instance of `Helius` if successful. A `HeliusError` is returned if an error occurs during configuration or initialization of the HTTP, RPC, or WS client
-    pub async fn new_with_ws(
+    pub async fn new_with_ws_with_timeouts(
         api_key: &str,
         cluster: Cluster,
         ping_interval_secs: Option<u64>,
@@ -132,8 +132,8 @@ impl Helius {
     ///
     /// # Returns
     /// An instance of `Helius` if successful. A `HeliusError` is returned if an error occurs during configuration or initialization of the HTTP, RPC, or WS client
-    pub async fn new_with_ws_default(api_key: &str, cluster: Cluster) -> Result<Self> {
-        Self::new_with_ws(api_key, cluster, None, None).await
+    pub async fn new_with_ws(api_key: &str, cluster: Cluster) -> Result<Self> {
+        Self::new_with_ws_with_timeouts(api_key, cluster, None, None).await
     }
 
     /// Provides a thread-safe way to access RPC functionalities

--- a/src/client.rs
+++ b/src/client.rs
@@ -97,17 +97,21 @@ impl Helius {
     /// * `cluster` - The Solana cluster (Devnet or MainnetBeta) that defines the given network environment
     /// * `ping_interval_secs` - Optional duration in seconds between ping messages (defaults to 10 seconds if None)
     /// * `pong_timeout_secs` - Optional duration in seconds to wait for a pong response before considering the connection dead
-    /// 
+    ///
     /// # Returns
     /// An instance of `Helius` if successful. A `HeliusError` is returned if an error occurs during configuration or initialization of the HTTP, RPC, or WS client
-    pub async fn new_with_ws(api_key: &str, cluster: Cluster, ping_interval_secs: Option<u64>, pong_timeout_secs: Option<u64>) -> Result<Self> {
+    pub async fn new_with_ws(
+        api_key: &str,
+        cluster: Cluster,
+        ping_interval_secs: Option<u64>,
+        pong_timeout_secs: Option<u64>,
+    ) -> Result<Self> {
         let config: Arc<Config> = Arc::new(Config::new(api_key, cluster)?);
         let client: Client = Client::builder().build().map_err(HeliusError::ReqwestError)?;
         let rpc_client: Arc<RpcClient> = Arc::new(RpcClient::new(Arc::new(client.clone()), config.clone())?);
         let wss: String = format!("{}{}", ENHANCED_WEBSOCKET_URL, api_key);
-        let ws_client: Arc<EnhancedWebsocket> = Arc::new(
-            EnhancedWebsocket::new(&wss, ping_interval_secs, pong_timeout_secs).await?
-        );
+        let ws_client: Arc<EnhancedWebsocket> =
+            Arc::new(EnhancedWebsocket::new(&wss, ping_interval_secs, pong_timeout_secs).await?);
 
         Ok(Helius {
             config,

--- a/src/client.rs
+++ b/src/client.rs
@@ -95,14 +95,19 @@ impl Helius {
     /// # Arguments
     /// * `api_key` - The API key required for authenticating requests made
     /// * `cluster` - The Solana cluster (Devnet or MainnetBeta) that defines the given network environment
+    /// * `ping_interval_secs` - Optional duration in seconds between ping messages (defaults to 10 seconds if None)
+    /// * `pong_timeout_secs` - Optional duration in seconds to wait for a pong response before considering the connection dead
+    /// 
     /// # Returns
     /// An instance of `Helius` if successful. A `HeliusError` is returned if an error occurs during configuration or initialization of the HTTP, RPC, or WS client
-    pub async fn new_with_ws(api_key: &str, cluster: Cluster) -> Result<Self> {
+    pub async fn new_with_ws(api_key: &str, cluster: Cluster, ping_interval_secs: Option<u64>, pong_timeout_secs: Option<u64>) -> Result<Self> {
         let config: Arc<Config> = Arc::new(Config::new(api_key, cluster)?);
         let client: Client = Client::builder().build().map_err(HeliusError::ReqwestError)?;
         let rpc_client: Arc<RpcClient> = Arc::new(RpcClient::new(Arc::new(client.clone()), config.clone())?);
         let wss: String = format!("{}{}", ENHANCED_WEBSOCKET_URL, api_key);
-        let ws_client: Arc<EnhancedWebsocket> = Arc::new(EnhancedWebsocket::new(&wss).await?);
+        let ws_client: Arc<EnhancedWebsocket> = Arc::new(
+            EnhancedWebsocket::new(&wss, ping_interval_secs, pong_timeout_secs).await?
+        );
 
         Ok(Helius {
             config,
@@ -111,6 +116,20 @@ impl Helius {
             async_rpc_client: None,
             ws_client: Some(ws_client),
         })
+    }
+
+    /// Creates a new instance of `Helius` with an enhanced websocket client using default timeout settings.
+    /// This is a convenience method that uses default values of 10 seconds for ping interval and 3 failed pings
+    /// before considering the connection dead.
+    ///
+    /// # Arguments
+    /// * `api_key` - The API key required for authenticating requests made
+    /// * `cluster` - The Solana cluster (Devnet or MainnetBeta) that defines the given network environment
+    ///
+    /// # Returns
+    /// An instance of `Helius` if successful. A `HeliusError` is returned if an error occurs during configuration or initialization of the HTTP, RPC, or WS client
+    pub async fn new_with_ws_default(api_key: &str, cluster: Cluster) -> Result<Self> {
+        Self::new_with_ws(api_key, cluster, None, None).await
     }
 
     /// Provides a thread-safe way to access RPC functionalities

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -269,6 +269,9 @@ impl EnhancedWebsocket {
                   None => break,
                 };
 
+                // Reset unmatched_pings on any received frame
+                unmatched_pings = 0;
+
                 // Get text from the message
                 let text = match msg {
                   Message::Text(text) => text,
@@ -278,7 +281,6 @@ impl EnhancedWebsocket {
                       continue
                   },
                   Message::Pong(_data) => {
-                    unmatched_pings = 0;
                     continue;
                   },
                   Message::Close(_frame) => break,

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -62,9 +62,9 @@ impl EnhancedWebsocket {
 
         let ping_interval = ping_interval_secs.unwrap_or(DEFAULT_PING_DURATION_SECONDS);
         let max_failed_pings = if let Some(timeout) = pong_timeout_secs {
-          (timeout as f64 / ping_interval as f64).ceil() as usize
+            (timeout as f64 / ping_interval as f64).ceil() as usize
         } else {
-          DEFAULT_MAX_FAILED_PINGS
+            DEFAULT_MAX_FAILED_PINGS
         };
 
         Ok(Self {

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -30,8 +30,8 @@ use tokio_tungstenite::{
 };
 
 pub const ENHANCED_WEBSOCKET_URL: &str = "wss://atlas-mainnet.helius-rpc.com/?api-key=";
-const DEFAULT_PING_DURATION_SECONDS: u64 = 10;
-const DEFAULT_MAX_FAILED_PINGS: usize = 3;
+pub const DEFAULT_PING_DURATION_SECONDS: u64 = 10;
+pub const DEFAULT_MAX_FAILED_PINGS: usize = 3;
 
 // pub type Result<T = ()> = Result<T, HeliusError>;
 

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -41,7 +41,7 @@ type SubscribeRequestMsg = (String, Value, oneshot::Sender<SubscribeResponseMsg>
 type SubscribeResult<'a, T> = Result<(BoxStream<'a, T>, UnsubscribeFn)>;
 type RequestMsg = (String, Value, oneshot::Sender<Result<Value>>);
 
-/// A client for subscribing to transaction or account updates from a Helius (geyser) enhanced websocket server.
+/// A client for subscribing to transaction or account updates from a Helius (Geyser) enhanced websocket server.
 ///
 /// Forked from Solana's [`PubsubClient`].
 pub struct EnhancedWebsocket {

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -60,16 +60,18 @@ impl EnhancedWebsocket {
         let (_request_sender, request_receiver) = mpsc::unbounded_channel();
         let (shutdown_sender, shutdown_receiver) = oneshot::channel();
 
-        let ping_interval = ping_interval_secs.filter(|interval: &u64| *interval !=0).unwrap_or(DEFAULT_PING_DURATION_SECONDS);
+        let ping_interval = ping_interval_secs
+            .filter(|interval: &u64| *interval != 0)
+            .unwrap_or(DEFAULT_PING_DURATION_SECONDS);
         let max_failed_pings = pong_timeout_secs
-          .map(|timeout| (timeout as f64 / ping_interval as f64).ceil() as usize)
-          .map_or(DEFAULT_MAX_FAILED_PINGS, |max_failed_pings| {
-            if max_failed_pings != 0 {
-              max_failed_pings
-            } else {
-              usize::MAX
-            }
-          });
+            .map(|timeout| (timeout as f64 / ping_interval as f64).ceil() as usize)
+            .map_or(DEFAULT_MAX_FAILED_PINGS, |max_failed_pings| {
+                if max_failed_pings != 0 {
+                    max_failed_pings
+                } else {
+                    usize::MAX
+                }
+            });
 
         Ok(Self {
             subscribe_sender,


### PR DESCRIPTION
This PR aims to implement better health checks for websockets by integrating better health connection monitoring via ping-pongs. Users can now configure the duration between ping messages and the duration to wait for a pong response before considering the connection dead using the new `new_with_ws_with_timeouts` method

Users can continue using `new_with_ws` without any hiccups, as this PR is designed to be backwards compatible with the default values