### PR TITLE
fix(deps): Remove Patch, Fix Dep Conflicts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,17 +20,17 @@ futures-util = "0.3.30"
 mpl-token-metadata = { version = "5.0.0-beta.0" }
 phf = { version = "0.11.2", features = ["macros"] }
 rand = "0.8.5"
-reqwest = { version = "0.12.8", features = ["json", "native-tls"] }
+reqwest = { version = "0.11.22", features = ["json", "native-tls"] }
 semver = "1.0.23"
 serde = "1.0.198"
 serde-enum-str = "0.4.0"
 serde_json = "1.0.116"
-solana-account-decoder = "2.0"
-solana-client = "2.0"
-solana-program = "2.0"
-solana-rpc-client-api = "2.0"
-solana-sdk = "2.0"
-solana-transaction-status = "2.0"
+solana-account-decoder = "2.1.4"
+solana-client = "2.1.4"
+solana-program = "2.1.4"
+solana-rpc-client-api = "2.1.4"
+solana-sdk = "2.1.4"
+solana-transaction-status = "2.1.4"
 thiserror = "1.0.58"
 tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread", "net", "time"] }
 tokio-stream = "0.1.15"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,3 @@ rustls = [
     "reqwest/rustls-tls",
     "tokio-tungstenite/rustls-tls-webpki-roots"
 ]
-
-[patch.crates-io]
-# https://github.com/solana-labs/solana/issues/26688#issuecomment-2136066879
-# For curve25519-dalek use the same revision Solana uses
-# https://github.com/solana-labs/solana/blob/27eff8408b7223bb3c4ab70523f8a8dca3ca6645/Cargo.toml#L475-L563
-curve25519-dalek = { git = "https://github.com/solana-labs/curve25519-dalek.git", rev = "b500cdc2a920cd5bff9e2dd974d7b97349d61464" }


### PR DESCRIPTION
This PR aims to resolve #96 by fixing all dep-related issues. I've removed the patch for `curve25519-dalek` as it's no longer required, as well as updated all Solana-related deps to the latest version