### PR TITLE
fix(types): Incorrect Field Renaming

### DIFF
--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -357,7 +357,6 @@ pub struct Asset {
     pub mutable: bool,
     pub burnt: bool,
     pub mint_extensions: Option<Value>,
-    #[serde(rename = "tokenSupply")]
     pub token_info: Option<TokenInfo>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub group_definition: Option<GroupDefinition>,


### PR DESCRIPTION
This PR aims to resolve #100 by removing the incorrect renaming of `token_info`