### PR TITLE
feat(cNFT): Mark mint_compressed_nft as Deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,9 @@ Our SDK is designed to provide a seamless developer experience when building on 
 - [`get_token_accounts`](https://docs.helius.dev/compression-and-das-api/digital-asset-standard-das-api/get-token-accounts) - Gets information about all token accounts for a specific mint or owner
 - [`get_nft_edition`](https://docs.helius.dev/compression-and-das-api/digital-asset-standard-das-api/get-nft-editions) - Gets all the NFT editions  associated with a specific master NFT
 
-### Mint API
+### Mint API (Deprecated)
 - [`delegate_collection_authority`](https://github.com/helius-labs/helius-rust-sdk/blob/6d3630c5fbafaaf450302789251ffaeed3cf7fcc/src/mint_api.rs#L24-L59) - Delegates collection authority to a new authority for a given collection mint
-- [`mint_compressed_nft`](https://docs.helius.dev/compression-and-das-api/mint-api/mint-compressed-nft) - The easiest way to mint a compressed NFT (cNFT)
+- [`mint_compressed_nft`](https://docs.helius.dev/compression-and-das-api/deprecated-mint-api) - The easiest way to mint a compressed NFT (cNFT)
 - [`revoke_collection_authority`](https://github.com/helius-labs/helius-rust-sdk/blob/6d3630c5fbafaaf450302789251ffaeed3cf7fcc/src/mint_api.rs#L61-L93) - Revokes a delegated collection authority for a given collection mint
 
 ### Enhanced Transactions API

--- a/examples/mint_cnft.rs
+++ b/examples/mint_cnft.rs
@@ -39,6 +39,7 @@ async fn main() -> Result<()> {
         confirm_transaction: Some(true),
     };
 
+    #[allow(deprecated)]
     let response: Result<MintResponse> = helius.mint_compressed_nft(request).await;
     println!("Assets: {:?}", response);
 

--- a/src/mint_api.rs
+++ b/src/mint_api.rs
@@ -17,6 +17,10 @@ impl Helius {
     ///
     /// # Returns
     /// A `Result` containing a `MintResponse` detailing the transaction signature, asset ID, and whether the cNFT was minted successfully
+    #[deprecated(
+        since = "0.2.5",
+        note = "Please refer to ZK Compression for all future compression-related work: https://docs.helius.dev/zk-compression-and-photon-api/what-is-zk-compression-on-solana"
+    )]
     pub async fn mint_compressed_nft(&self, request: MintCompressedNftRequest) -> Result<MintResponse> {
         self.rpc_client.post_rpc_request("mintCompressedNft", request).await
     }

--- a/tests/test_mint_api.rs
+++ b/tests/test_mint_api.rs
@@ -81,6 +81,7 @@ async fn test_mint_compressed_nft() {
         confirm_transaction: Some(true),
     };
 
+    #[allow(deprecated)]
     let result: Result<MintResponse> = helius.mint_compressed_nft(request).await;
     assert!(result.is_ok(), "API call failed with error: {:?}", result.err());
 
@@ -156,6 +157,7 @@ async fn test_get_asset_proof_failure() {
         confirm_transaction: Some(true),
     };
 
+    #[allow(deprecated)]
     let result: Result<MintResponse> = helius.mint_compressed_nft(request).await;
     assert!(result.is_err(), "Expected an error but got success");
 }


### PR DESCRIPTION
This PR aims to tag `mint_compressed_nft` as deprecated, as we have deprecated the Mint API