### PR TITLE
Remove forced `native-tls` features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ futures-util = "0.3.30"
 mpl-token-metadata = { version = "5.0.0-beta.0" }
 phf = { version = "0.11.2", features = ["macros"] }
 rand = "0.8.5"
+reqwest = { version = "0.11.22", default-features = false }
 semver = "1.0.23"
 serde = "1.0.198"
 serde-enum-str = "0.4.0"
@@ -36,12 +37,6 @@ tokio-stream = "0.1.15"
 tokio-tungstenite = "0.24.0"
 url = "2.5.0"
 spl-token = { version = "6.0", features = ["no-entrypoint"] }
-
-[dependencies.reqwest]
-version = "0.11.22"
-default-features = false
-# Default features, minus `default-tls`
-features = ["json", "charset", "http2", "macos-system-configuration"]
 
 [dev-dependencies]
 mockito = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ solana-transaction-status = "2.1.4"
 thiserror = "1.0.58"
 tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread", "net", "time"] }
 tokio-stream = "0.1.15"
-tokio-tungstenite = { version = "0.24.0", features = ["native-tls"] }
+tokio-tungstenite = "0.24.0"
 url = "2.5.0"
 spl-token = { version = "6.0", features = ["no-entrypoint"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ futures-util = "0.3.30"
 mpl-token-metadata = { version = "5.0.0-beta.0" }
 phf = { version = "0.11.2", features = ["macros"] }
 rand = "0.8.5"
-reqwest = { version = "0.11.22", features = ["json", "native-tls"] }
 semver = "1.0.23"
 serde = "1.0.198"
 serde-enum-str = "0.4.0"
@@ -37,6 +36,12 @@ tokio-stream = "0.1.15"
 tokio-tungstenite = { version = "0.24.0", features = ["native-tls"] }
 url = "2.5.0"
 spl-token = { version = "6.0", features = ["no-entrypoint"] }
+
+[dependencies.reqwest]
+version = "0.11.22"
+default-features = false
+# Default features, minus `default-tls`
+features = ["json", "charset", "http2", "macos-system-configuration"]
 
 [dev-dependencies]
 mockito = "1.4.0"


### PR DESCRIPTION
Unconditionally enabling `native-tls` forces it on for all users, making it impossible to build or run without `libssl` on Linux.

It's already enabled by the default features of this crate, so there's no need to force it on.