### PR TITLE
fix(types): Add `Attributes` Enum

### DIFF
--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -578,8 +578,15 @@ pub struct FileQuality {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
+#[serde(untagged)]
+pub enum Attributes {
+    List(Vec<Attribute>),
+    Map(serde_json::Map<String, Value>),
+}
+
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Metadata {
-    pub attributes: Option<Vec<Attribute>>,
+    pub attributes: Option<Attributes>,
     pub description: Option<String>,
     pub name: Option<String>,
     pub symbol: Option<String>,

--- a/tests/rpc/test_get_asset.rs
+++ b/tests/rpc/test_get_asset.rs
@@ -42,7 +42,7 @@ async fn test_get_asset_success() {
                             ],
                         ),
                         metadata: Metadata {
-                            attributes: Some(
+                            attributes: Some(Attributes::List(
                                 vec![
                                     Attribute {
                                         value: Value::String("Common".to_string()),
@@ -57,7 +57,7 @@ async fn test_get_asset_success() {
                                         trait_type: "signed".to_string(),
                                     },
                                 ],
-                            ),
+                            )),
                             description: Some(
                                 "Apt323 the 36 page Collectors Edition.".to_string(),
                             ),

--- a/tests/rpc/test_get_asset_batch.rs
+++ b/tests/rpc/test_get_asset_batch.rs
@@ -5,7 +5,9 @@ use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
 use helius::types::{
-    ApiResponse, Asset, Attribute, Attributes, Authorities, Cluster, CollectionMetadata, Compression, Content, Creator, File, GetAssetBatch, GetAssetOptions, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty, RoyaltyModel, Scope, Supply
+    ApiResponse, Asset, Attribute, Attributes, Authorities, Cluster, CollectionMetadata, Compression, Content, Creator,
+    File, GetAssetBatch, GetAssetOptions, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership,
+    OwnershipModel, Royalty, RoyaltyModel, Scope, Supply,
 };
 
 use mockito::{self, Server};

--- a/tests/rpc/test_get_asset_batch.rs
+++ b/tests/rpc/test_get_asset_batch.rs
@@ -5,9 +5,7 @@ use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
 use helius::types::{
-    ApiResponse, Asset, Attribute, Authorities, Cluster, CollectionMetadata, Compression, Content, Creator, File,
-    GetAssetBatch, GetAssetOptions, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel,
-    Royalty, RoyaltyModel, Scope, Supply,
+    ApiResponse, Asset, Attribute, Attributes, Authorities, Cluster, CollectionMetadata, Compression, Content, Creator, File, GetAssetBatch, GetAssetOptions, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty, RoyaltyModel, Scope, Supply
 };
 
 use mockito::{self, Server};
@@ -36,7 +34,7 @@ async fn test_get_asset_batch_success() {
                         contexts: None,
                     }]),
                     metadata: Metadata {
-                        attributes: Some(vec![
+                        attributes: Some(Attributes::List(vec![
                             Attribute {
                                 value: Value::String("112vepK9Upx7juv4pCdwqzm7reBo6VYEQHKRNmU6PEaKX1ese5NE".to_string()),
                                 trait_type: "ecc_compact".to_string(),
@@ -45,7 +43,7 @@ async fn test_get_asset_batch_success() {
                                 value: Value::Bool(true),
                                 trait_type: "rewardable".to_string(),
                             }
-                        ]),
+                        ])),
                         description: Some("A hotspot NFT on Helium".to_string()),
                         name: Some("gentle-mandarin-ferret".to_string()),
                         symbol: Some("HOTSPOT".to_string()),
@@ -141,7 +139,7 @@ async fn test_get_asset_batch_success() {
                         },
                     ]),
                     metadata: Metadata {
-                        attributes: Some(vec![
+                        attributes: Some(Attributes::List(vec![
                             Attribute {
                                 value: serde_json::Value::String("1".to_string()),
                                 trait_type: "Season".to_string(),
@@ -154,7 +152,7 @@ async fn test_get_asset_batch_success() {
                                 value: serde_json::Value::String("Legendary".to_string()),
                                 trait_type: "Rarity".to_string(),
                             }
-                        ]),
+                        ])),
                         description: Some("Aerial photograph of a parking structure in LA depicting the photographer, Andrew Mason, \"sliding\" through the image.".to_string()),
                         name: Some("Slide".to_string()),
                         symbol: Some("".to_string()),

--- a/tests/rpc/test_get_assets_by_authority.rs
+++ b/tests/rpc/test_get_assets_by_authority.rs
@@ -2,7 +2,9 @@ use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
 use helius::types::{
-    ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File, GetAssetsByAuthority, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty, RoyaltyModel, Scope, Supply
+    ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File,
+    GetAssetsByAuthority, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty,
+    RoyaltyModel, Scope, Supply,
 };
 use helius::Helius;
 

--- a/tests/rpc/test_get_assets_by_authority.rs
+++ b/tests/rpc/test_get_assets_by_authority.rs
@@ -2,9 +2,7 @@ use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
 use helius::types::{
-    ApiResponse, Asset, AssetList, Attribute, Authorities, Cluster, Compression, Content, Creator, File,
-    GetAssetsByAuthority, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty,
-    RoyaltyModel, Scope, Supply,
+    ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File, GetAssetsByAuthority, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty, RoyaltyModel, Scope, Supply
 };
 use helius::Helius;
 
@@ -69,7 +67,7 @@ async fn test_get_assets_by_authority_success() {
                                 ],
                             ),
                             metadata: Metadata {
-                                attributes: Some(
+                                attributes: Some(Attributes::List(
                                     vec![
                                         Attribute {
                                             value: Value::String("Male".to_string()),
@@ -96,7 +94,7 @@ async fn test_get_assets_by_authority_success() {
                                             trait_type: "Background".to_string(),
                                         },
                                     ],
-                                ),
+                                )),
                                 description: Some(
                                     "Fock it.".to_string(),
                                 ),

--- a/tests/rpc/test_get_assets_by_creator.rs
+++ b/tests/rpc/test_get_assets_by_creator.rs
@@ -2,7 +2,9 @@ use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
 use helius::types::{
-    ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File, GetAssetsByCreator, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty, RoyaltyModel, Scope, Supply
+    ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File,
+    GetAssetsByCreator, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty,
+    RoyaltyModel, Scope, Supply,
 };
 use helius::Helius;
 

--- a/tests/rpc/test_get_assets_by_creator.rs
+++ b/tests/rpc/test_get_assets_by_creator.rs
@@ -2,9 +2,7 @@ use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
 use helius::types::{
-    ApiResponse, Asset, AssetList, Attribute, Authorities, Cluster, Compression, Content, Creator, File,
-    GetAssetsByCreator, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty,
-    RoyaltyModel, Scope, Supply,
+    ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File, GetAssetsByCreator, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty, RoyaltyModel, Scope, Supply
 };
 use helius::Helius;
 
@@ -69,7 +67,7 @@ async fn test_get_assets_by_creator_success() {
                         ],
                     ),
                     metadata: Metadata {
-                        attributes: Some(
+                        attributes: Some(Attributes::List(
                             vec![
                                 Attribute {
                                     value: Value::String("Male".to_string()),
@@ -96,7 +94,7 @@ async fn test_get_assets_by_creator_success() {
                                     trait_type: "Background".to_string(),
                                 },
                             ],
-                        ),
+                        )),
                         description: Some(
                             "Fock it.".to_string(),
                         ),

--- a/tests/rpc/test_get_assets_by_group.rs
+++ b/tests/rpc/test_get_assets_by_group.rs
@@ -40,7 +40,7 @@ async fn test_get_assets_by_group_success() {
                             contexts: None,
                         }]),
                         metadata: Metadata {
-                            attributes: Some(vec![Attribute {
+                            attributes: Some(Attributes::List(vec![Attribute {
                                 value: Value::String("Jedi Master".to_string()),
                                 trait_type: "Rank".to_string(),
                             }, Attribute {
@@ -49,7 +49,7 @@ async fn test_get_assets_by_group_success() {
                             }, Attribute {
                                 value: Value::String("Jedi Order".to_string()),
                                 trait_type: "Affiliation".to_string(),
-                            }]),
+                            }])),
                             description: Some("Obi-Wan Kenobi was a legendary Force-sensitive human male Jedi Master who served on the Jedi High Council during the final years of the Republic Era".to_string()),
                             name: Some("Obi-Wan Kenobi".to_string()),
                             symbol: Some("Guiding Light".to_string()),

--- a/tests/rpc/test_get_assets_by_owner.rs
+++ b/tests/rpc/test_get_assets_by_owner.rs
@@ -2,7 +2,9 @@ use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
 use helius::types::{
-    ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File, GetAssetsByOwner, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty, RoyaltyModel, Scope, Supply
+    ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File,
+    GetAssetsByOwner, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty,
+    RoyaltyModel, Scope, Supply,
 };
 use helius::Helius;
 

--- a/tests/rpc/test_get_assets_by_owner.rs
+++ b/tests/rpc/test_get_assets_by_owner.rs
@@ -2,9 +2,7 @@ use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
 use helius::types::{
-    ApiResponse, Asset, AssetList, Attribute, Authorities, Cluster, Compression, Content, Creator, File,
-    GetAssetsByOwner, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty,
-    RoyaltyModel, Scope, Supply,
+    ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File, GetAssetsByOwner, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty, RoyaltyModel, Scope, Supply
 };
 use helius::Helius;
 
@@ -45,7 +43,7 @@ async fn test_get_assets_by_owner_success() {
                         contexts: None,
                     }]),
                     metadata: Metadata {
-                        attributes: Some(vec![
+                        attributes: Some(Attributes::List(vec![
                             Attribute {
                                 value: Value::String("https://3000jup.com".to_string()),
                                 trait_type: "Website".to_string(),
@@ -62,7 +60,7 @@ async fn test_get_assets_by_owner_success() {
                                 value: Value::String("35 minutes!".to_string()),
                                 trait_type: "Time Left".to_string(),
                             },
-                        ]),
+                        ])),
                         description: Some(
                             "Visit the domain shown in the picture and claim your exclusive voucher 3000jup.com"
                                 .to_string(),

--- a/tests/rpc/test_search_assets.rs
+++ b/tests/rpc/test_search_assets.rs
@@ -2,7 +2,9 @@ use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
 use helius::types::{
-    ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty, RoyaltyModel, Scope, SearchAssets, Supply
+    ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File,
+    Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty, RoyaltyModel, Scope,
+    SearchAssets, Supply,
 };
 use helius::Helius;
 

--- a/tests/rpc/test_search_assets.rs
+++ b/tests/rpc/test_search_assets.rs
@@ -2,9 +2,7 @@ use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
 use helius::types::{
-    ApiResponse, Asset, AssetList, Attribute, Authorities, Cluster, Compression, Content, Creator, File, Group,
-    HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty, RoyaltyModel, Scope, SearchAssets,
-    Supply,
+    ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty, RoyaltyModel, Scope, SearchAssets, Supply
 };
 use helius::Helius;
 
@@ -45,7 +43,7 @@ async fn test_search_assets_success() {
                         contexts: None,
                     }]),
                     metadata: Metadata {
-                        attributes: Some(vec![
+                        attributes: Some(Attributes::List(vec![
                             Attribute {
                                 value: Value::String("https://3000jup.com".to_string()),
                                 trait_type: "Website".to_string(),
@@ -62,7 +60,7 @@ async fn test_search_assets_success() {
                                 value: Value::String("35 minutes!".to_string()),
                                 trait_type: "Time Left".to_string(),
                             },
-                        ]),
+                        ])),
                         description: Some(
                             "Visit the domain shown in the picture and claim your exclusive voucher 3000jup.com"
                                 .to_string(),


### PR DESCRIPTION
This PR aims to resolve #114, where `Metadata` would have the wrong data structure for some assets, by adding in a new `Attributes` enum