### PR TITLE
fix: make asset_id field in GroupDefinition optional

### DIFF
--- a/src/types/types.rs
+++ b/src/types/types.rs
@@ -695,8 +695,8 @@ pub struct GroupDefinition {
     pub group_value: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<u64>,
-    #[serde(skip_serializing)]
-    pub asset_id: Vec<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub asset_id: Option<Vec<u8>>,
 }
 
 // #[derive(Debug, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
## Problem
When querying the account `9apnHjEQ8enLaPLxP7z9VQTphWE4nWqZcyHJYocQMpSE` via `searchAssets`, the asset `5gVSjqSbBhrCsUFz3pE6ZnrNiEyxMXzmN92XPTc4b9kS` is returned with a non-null `GroupDefintion` field which doesn't include an `asset_id` field. 

This leads to a failed deser of the `GroupDefintion` struct and the subsequent `Asset` and `AssetList` structs

## Fix
Make the `asset_id` field in the `GroupDefintion` struct optional