### PR TITLE
feat(staking): Add Staking Functionality

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tokio-stream = "0.1.15"
 tokio-tungstenite = "0.24.0"
 url = "2.5.0"
 spl-token = { version = "6.0", features = ["no-entrypoint"] }
+once_cell = "1.21.3"
 
 [dev-dependencies]
 mockito = "1.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod mint_api;
 pub mod optimized_transaction;
 pub mod request_handler;
 pub mod rpc_client;
+pub mod staking;
 pub mod types;
 pub mod utils;
 pub mod webhook;

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -1,0 +1,83 @@
+use std::str::FromStr;
+
+use crate::{Helius, error::{HeliusError, Result}};
+
+use bincode;
+use once_cell::sync::Lazy;
+use solana_sdk::{
+    bs58, native_token::LAMPORTS_PER_SOL, pubkey::Pubkey, signer::{keypair::Keypair, Signer}, stake::{
+        self, instruction as stake_instruction, state::{Authorized, StakeStateV2}
+    }, transaction::Transaction, instruction::Instruction
+};
+use solana_program::hash::Hash;
+
+pub static HELIUS_VALIDATOR_PUBKEY: Lazy<Pubkey> = Lazy::new(|| {
+    Pubkey::from_str("he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk").expect("Invalid Pubkey")
+});
+
+impl Helius {
+    /// Generate an unsigned, base58-encoded transaction that creates and delegates a new stake account
+    ///
+    /// This transaction must be signed by the funder's wallet before broadcasting. It delegates stake
+    /// to the Helius validator, and includes enough lamports to cover both the specified stake amount
+    /// and the rent-exempt minimum for a stake account
+    ///
+    /// # Arguments
+    ///
+    /// * `owner` - The public key of the wallet funding and authorizing the stake
+    /// * `amount_sol` - The amount of SOL to stake, **excluding** the rent-exempt minimum
+    ///
+    /// # Returns
+    ///
+    /// * A tuple of:
+    ///   - `String`: base58-encoded unsigned serialized transaction
+    ///   - `Pubkey`: the new stake account's public key
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if fetching the rent-exemption balance, blockhash, or serializing the transaction
+    /// fails
+    pub async fn create_stake_transaction(
+        &self,
+        owner: Pubkey,
+        amount_sol: f64,
+    ) -> Result<(String, Pubkey)> {
+        let rent_exempt: u64 = self.connection().get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())?;
+        let lamports: u64 = ((amount_sol * LAMPORTS_PER_SOL as f64).round() as u64) + rent_exempt;
+
+        let stake_account: Keypair = Keypair::new();
+
+        let authorized: Authorized = Authorized {
+            staker: owner,
+            withdrawer: owner,
+        };
+    
+        let create_ix: Vec<Instruction> = stake_instruction::create_account(
+            &owner,
+            &stake_account.pubkey(),
+            &authorized,
+            &stake::state::Lockup::default(),
+            lamports,
+        );
+
+        let delegate_ix: Instruction = stake_instruction::delegate_stake(
+            &stake_account.pubkey(),
+            &owner,
+            &HELIUS_VALIDATOR_PUBKEY,
+        );
+    
+        let blockhash: Hash = self.connection().get_latest_blockhash()?;
+        let mut instructions: Vec<Instruction> = create_ix;
+        instructions.push(delegate_ix);
+        
+        let mut tx: Transaction = Transaction::new_with_payer(&instructions, Some(&owner));
+        tx.partial_sign(&[&stake_account], blockhash);
+    
+        let serialized: Vec<u8> = bincode::serialize(&tx)
+            .map_err(|e| HeliusError::InvalidInput(format!("Failed to serialize transaction: {e}")))?;
+    
+        let encoded: String = bs58::encode(serialized).into_string();
+    
+        Ok((encoded, stake_account.pubkey()))
+    }
+}

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -1,20 +1,29 @@
 use std::str::FromStr;
 
-use crate::{Helius, error::{HeliusError, Result}};
+use crate::{
+    error::{HeliusError, Result},
+    Helius,
+};
 
 use bincode;
 use once_cell::sync::Lazy;
-use solana_sdk::{
-    bs58, commitment_config::CommitmentConfig, instruction::Instruction, native_token::LAMPORTS_PER_SOL, pubkey::Pubkey, signer::{keypair::Keypair, Signer}, stake::{
-        self, instruction as stake_instruction, state::{Authorized, StakeStateV2}
-    }, transaction::Transaction
-};
 use solana_program::hash::Hash;
+use solana_sdk::{
+    bs58,
+    commitment_config::CommitmentConfig,
+    instruction::Instruction,
+    native_token::LAMPORTS_PER_SOL,
+    pubkey::Pubkey,
+    signer::{keypair::Keypair, Signer},
+    stake::{
+        self, instruction as stake_instruction,
+        state::{Authorized, StakeStateV2},
+    },
+    transaction::Transaction,
+};
 
-
-pub static HELIUS_VALIDATOR_PUBKEY: Lazy<Pubkey> = Lazy::new(|| {
-    Pubkey::from_str("he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk").expect("Invalid Pubkey")
-});
+pub static HELIUS_VALIDATOR_PUBKEY: Lazy<Pubkey> =
+    Lazy::new(|| Pubkey::from_str("he1iusunGwqrNtafDtLdhsUQDFvo13z9sUa36PauBtk").expect("Invalid Pubkey"));
 
 impl Helius {
     /// Generate an unsigned, base58-encoded transaction that creates and delegates a new stake account
@@ -38,12 +47,10 @@ impl Helius {
     ///
     /// Returns an error if fetching the rent-exemption balance, blockhash, or serializing the transaction
     /// fails
-    pub async fn create_stake_transaction(
-        &self,
-        owner: Pubkey,
-        amount_sol: f64,
-    ) -> Result<(String, Pubkey)> {
-        let rent_exempt: u64 = self.connection().get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())?;
+    pub async fn create_stake_transaction(&self, owner: Pubkey, amount_sol: f64) -> Result<(String, Pubkey)> {
+        let rent_exempt: u64 = self
+            .connection()
+            .get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())?;
         let lamports: u64 = ((amount_sol * LAMPORTS_PER_SOL as f64).round() as u64) + rent_exempt;
 
         let stake_account: Keypair = Keypair::new();
@@ -52,7 +59,7 @@ impl Helius {
             staker: owner,
             withdrawer: owner,
         };
-    
+
         let create_ix: Vec<Instruction> = stake_instruction::create_account(
             &owner,
             &stake_account.pubkey(),
@@ -61,24 +68,21 @@ impl Helius {
             lamports,
         );
 
-        let delegate_ix: Instruction = stake_instruction::delegate_stake(
-            &stake_account.pubkey(),
-            &owner,
-            &HELIUS_VALIDATOR_PUBKEY,
-        );
-    
+        let delegate_ix: Instruction =
+            stake_instruction::delegate_stake(&stake_account.pubkey(), &owner, &HELIUS_VALIDATOR_PUBKEY);
+
         let blockhash: Hash = self.connection().get_latest_blockhash()?;
         let mut instructions: Vec<Instruction> = create_ix;
         instructions.push(delegate_ix);
-        
+
         let mut tx: Transaction = Transaction::new_with_payer(&instructions, Some(&owner));
         tx.partial_sign(&[&stake_account], blockhash);
-    
+
         let serialized: Vec<u8> = bincode::serialize(&tx)
             .map_err(|e| HeliusError::InvalidInput(format!("Failed to serialize transaction: {e}")))?;
-    
+
         let encoded: String = bs58::encode(serialized).into_string();
-    
+
         Ok((encoded, stake_account.pubkey()))
     }
 
@@ -99,22 +103,12 @@ impl Helius {
     /// # Errors
     ///
     /// Returns an error if fetching the latest blockhash or serializing the transaction fails
-    pub async fn create_unstake_transaction(
-        &self,
-        owner: Pubkey,
-        stake_account: Pubkey,
-    ) -> Result<String> {
-        let deactivate_ix: Instruction = stake_instruction::deactivate_stake(
-            &stake_account,
-            &owner,
-        );
+    pub async fn create_unstake_transaction(&self, owner: Pubkey, stake_account: Pubkey) -> Result<String> {
+        let deactivate_ix: Instruction = stake_instruction::deactivate_stake(&stake_account, &owner);
 
         let blockhash: Hash = self.connection().get_latest_blockhash()?;
 
-        let mut tx: Transaction = Transaction::new_with_payer(
-            &[deactivate_ix],
-            Some(&owner),
-        );
+        let mut tx: Transaction = Transaction::new_with_payer(&[deactivate_ix], Some(&owner));
 
         tx.message.recent_blockhash = blockhash;
 
@@ -175,7 +169,7 @@ impl Helius {
     /// Generate the instructions to create and delegate a new stake account with Helius
     ///
     /// This method only returns the `Vec<Instruction>` and the newly generated `Keypair` for the stake account
-    /// Note that **you** are responsible for building, signing, and sending the transaction. We recommend 
+    /// Note that **you** are responsible for building, signing, and sending the transaction. We recommend
     /// using this method with our smart transactions
     ///
     /// # Arguments
@@ -192,11 +186,7 @@ impl Helius {
     /// # Errors
     ///
     /// Returns an error if fetching the rent-exempt minimum balance fails
-    pub async fn get_stake_instructions(
-        &self,
-        owner: Pubkey,
-        amount_sol: f64,
-    ) -> Result<(Vec<Instruction>, Keypair)> {
+    pub async fn get_stake_instructions(&self, owner: Pubkey, amount_sol: f64) -> Result<(Vec<Instruction>, Keypair)> {
         let rent_exempt: u64 = self
             .connection()
             .get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())?;
@@ -218,13 +208,11 @@ impl Helius {
             lamports,
         );
 
-        instructions.push(
-            stake_instruction::delegate_stake(
-                &stake_account.pubkey(),
-                &owner,
-                &HELIUS_VALIDATOR_PUBKEY,
-            )
-        );
+        instructions.push(stake_instruction::delegate_stake(
+            &stake_account.pubkey(),
+            &owner,
+            &HELIUS_VALIDATOR_PUBKEY,
+        ));
 
         Ok((instructions, stake_account))
     }
@@ -243,16 +231,9 @@ impl Helius {
     /// # Returns
     ///
     /// * `Instruction` - The `deactivate_stake` instruction
-pub fn get_unstake_instruction(
-    &self,
-    owner: Pubkey,
-    stake_account: Pubkey,
-) -> Instruction {
-    stake_instruction::deactivate_stake(
-        &stake_account,
-        &owner,
-    )
-}
+    pub fn get_unstake_instruction(&self, owner: Pubkey, stake_account: Pubkey) -> Instruction {
+        stake_instruction::deactivate_stake(&stake_account, &owner)
+    }
 
     /// Generates an instruction to withdraw lamports from a given stake account
     ///
@@ -270,80 +251,70 @@ pub fn get_unstake_instruction(
     /// # Returns
     ///
     /// * `Instruction` - The `withdraw` instruction
-pub fn get_withdraw_instruction(
-    &self,
-    owner: Pubkey,
-    stake_account: Pubkey,
-    destination: Pubkey,
-    lamports: u64,
-) -> Instruction {
-    stake_instruction::withdraw(
-        &stake_account,
-        &owner,
-        &destination,
-        lamports,
-        None,
-    )
-}
+    pub fn get_withdraw_instruction(
+        &self,
+        owner: Pubkey,
+        stake_account: Pubkey,
+        destination: Pubkey,
+        lamports: u64,
+    ) -> Instruction {
+        stake_instruction::withdraw(&stake_account, &owner, &destination, lamports, None)
+    }
 
-/// Determine how many lamports are withdrawable from a stake account
-///
-/// This checks whether the stake account is fully deactivated and cooled down,
-/// and subtracts the rent-exempt minimum unless explicitly included.
-///
-/// # Arguments
-///
-/// * `stake_account` - The public key of the stake account to inspect
-/// * `include_rent_exempt` - Whether to include the rent-exempt minimum in the returned amount
-///
-/// # Returns
-///
-/// * `u64` - The number of lamports that can be withdrawn (0 if none)
-///
-/// # Errors
-///
-/// Returns an error if the account cannot be found or isn't a valid stake account
-pub async fn get_withdrawable_amount(
-    &self,
-    stake_account: Pubkey,
-    include_rent_exempt: bool,
-) -> Result<u64> {
-    let account = self
-        .connection()
-        .get_account_with_commitment(&stake_account, CommitmentConfig::confirmed())?
-        .value
-        .ok_or_else(|| HeliusError::NotFound {
-            text: format!("Stake account {} not found", stake_account),
-        })?;
+    /// Determine how many lamports are withdrawable from a stake account
+    ///
+    /// This checks whether the stake account is fully deactivated and cooled down,
+    /// and subtracts the rent-exempt minimum unless explicitly included.
+    ///
+    /// # Arguments
+    ///
+    /// * `stake_account` - The public key of the stake account to inspect
+    /// * `include_rent_exempt` - Whether to include the rent-exempt minimum in the returned amount
+    ///
+    /// # Returns
+    ///
+    /// * `u64` - The number of lamports that can be withdrawn (0 if none)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the account cannot be found or isn't a valid stake account
+    pub async fn get_withdrawable_amount(&self, stake_account: Pubkey, include_rent_exempt: bool) -> Result<u64> {
+        let account = self
+            .connection()
+            .get_account_with_commitment(&stake_account, CommitmentConfig::confirmed())?
+            .value
+            .ok_or_else(|| HeliusError::NotFound {
+                text: format!("Stake account {} not found", stake_account),
+            })?;
 
-    let lamports = account.lamports;
+        let lamports = account.lamports;
 
-    let state: StakeStateV2 = bincode::deserialize(&account.data)
-        .map_err(|_| HeliusError::InvalidInput("Failed to parse stake account".into()))?;
+        let state: StakeStateV2 = bincode::deserialize(&account.data)
+            .map_err(|_| HeliusError::InvalidInput("Failed to parse stake account".into()))?;
 
-    let deactivation_epoch = match state {
-        StakeStateV2::Stake(_, stake, _) => stake.delegation.deactivation_epoch,
-        _ => {
-            return Err(HeliusError::InvalidInput(
-                "Account is not a valid delegated stake account".into(),
-            ));
+        let deactivation_epoch = match state {
+            StakeStateV2::Stake(_, stake, _) => stake.delegation.deactivation_epoch,
+            _ => {
+                return Err(HeliusError::InvalidInput(
+                    "Account is not a valid delegated stake account".into(),
+                ));
+            }
+        };
+
+        let current_epoch = self.connection().get_epoch_info()?.epoch;
+
+        if deactivation_epoch > current_epoch {
+            return Ok(0); // Still cooling down
         }
-    };
 
-    let current_epoch = self.connection().get_epoch_info()?.epoch;
+        if include_rent_exempt {
+            return Ok(lamports);
+        }
 
-    if deactivation_epoch > current_epoch {
-        return Ok(0); // Still cooling down
+        let rent_exempt = self
+            .connection()
+            .get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())?;
+
+        Ok(lamports.saturating_sub(rent_exempt))
     }
-
-    if include_rent_exempt {
-        return Ok(lamports);
-    }
-
-    let rent_exempt = self
-        .connection()
-        .get_minimum_balance_for_rent_exemption(StakeStateV2::size_of())?;
-
-    Ok(lamports.saturating_sub(rent_exempt))
-}
 }

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -7,7 +7,7 @@ use crate::{
 
 use bincode;
 use once_cell::sync::Lazy;
-use solana_account_decoder::UiAccountEncoding; // we still need only the enum
+use solana_account_decoder::UiAccountEncoding;
 use solana_client::{
     rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
     rpc_filter::{Memcmp, MemcmpEncodedBytes, RpcFilterType},


### PR DESCRIPTION
This PR aims to add staking functionality via the following methods:
- `create_stake_transaction`
- `create_unstake_transaction`
- `create_withdraw_transaction`
- `get_stake_instructions`
- `get_unstake_instruction`
- `get_withdraw_instruction`
- `get_withdrawable_amount`
- `get_stake_accounts`