### PR TITLE
Add the missing json feature of reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ futures-util = "0.3.30"
 mpl-token-metadata = { version = "5.0.0-beta.0" }
 phf = { version = "0.11.2", features = ["macros"] }
 rand = "0.8.5"
-reqwest = { version = "0.11.22", default-features = false }
+reqwest = { version = "0.11.22", features = ["json"], default-features = false }
 semver = "1.0.23"
 serde = "1.0.198"
 serde-enum-str = "0.4.0"


### PR DESCRIPTION
Trying to fix this error:

```
error[E0599]: no method named `json` found for struct `reqwest::RequestBuilder` in the current scope
  --> src/request_handler.rs:65:47
   |
65 |             request_builder = request_builder.json(body);
   |                                               ^^^^ method not found in `RequestBuilder`

```

It's caused by https://github.com/seanmonstar/reqwest/issues/773