### PR TITLE
Feat: Add Commitment Level Support to Helius Client Initialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ solana-client = "2.1.4"
 solana-program = "2.1.4"
 solana-rpc-client-api = "2.1.4"
 solana-sdk = "2.1.4"
+solana-commitment-config = "2.1.4"
 solana-transaction-status = "2.1.4"
 thiserror = "1.0.58"
 tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread", "net", "time"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -73,6 +73,7 @@ impl Helius {
     /// ```rust
     /// use helius::client::Helius;
     /// use helius::types::Cluster;
+    /// use solana_commitment_config::CommitmentConfig;
     ///
     /// let helius = Helius::new_with_commitment("your_api_key", Cluster::Devnet, CommitmentConfig::confirmed()).expect("Failed to create a Helius client");
     /// ```
@@ -142,6 +143,7 @@ impl Helius {
     /// ```rust
     /// use helius::Helius;
     /// use helius::types::Cluster;
+    /// use solana_commitment_config::CommitmentConfig;
     ///
     /// let helius = Helius::new_with_async_solana_and_commitment("your_api_key", Cluster::Devnet, CommitmentConfig::confirmed()).expect("Failed to create a Helius client");
     /// ```

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,6 +9,7 @@ use crate::websocket::EnhancedWebsocket;
 use reqwest::Client;
 use solana_client::nonblocking::rpc_client::RpcClient as AsyncSolanaRpcClient;
 use solana_client::rpc_client::RpcClient as SolanaRpcClient;
+use solana_commitment_config::CommitmentConfig;
 
 /// The `Helius` struct is the main entry point to interacting with the SDK
 ///
@@ -58,6 +59,43 @@ impl Helius {
         })
     }
 
+    /// Creates a new instance of `Helius` configured with a specific API key, target cluster, and a commitment config
+    ///
+    /// # Arguments
+    /// * `api_key` - The API key required for authenticating the requests made
+    /// * `cluster` - The Solana cluster (Devnet or MainnetBeta) that defines the given network environment
+    /// * `commitment` - The commitment level to use for the Solana client
+    ///
+    /// # Returns
+    /// An instance of `Helius` if successful. A `HeliusError` is returned if an error occurs during configuration or initialization of the HTTP or RPC client
+    ///
+    /// # Example
+    /// ```rust
+    /// use helius::client::Helius;
+    /// use helius::types::Cluster;
+    ///
+    /// let helius = Helius::new_with_commitment("your_api_key", Cluster::Devnet, CommitmentConfig::confirmed()).expect("Failed to create a Helius client");
+    /// ```
+    pub fn new_with_commitment(api_key: &str, cluster: Cluster, commitment: CommitmentConfig) -> Result<Self> {
+        let config: Arc<Config> = Arc::new(Config::new(api_key, cluster)?);
+        let client: Client = Client::builder().build().map_err(HeliusError::ReqwestError)?;
+        let rpc_client: Arc<RpcClient> = Arc::new(RpcClient::new_with_commitment(
+            Arc::new(client.clone()),
+            config.clone(),
+            commitment,
+        )?);
+
+        Ok(Helius {
+            config,
+            client,
+            rpc_client,
+            async_rpc_client: None,
+            ws_client: None,
+        })
+    }
+
+    /// Creates a new instance of `Helius` with an asynchronous Solana client and a commitment config
+
     /// Creates a new instance of `Helius` with an asynchronous Solana client
     ///
     /// # Arguments
@@ -84,6 +122,49 @@ impl Helius {
             config: config.clone(),
             client: client.clone(),
             rpc_client: Arc::new(RpcClient::new(Arc::new(client), config.clone())?),
+            async_rpc_client: Some(async_solana_client),
+            ws_client: None,
+        })
+    }
+
+    /// Creates a new instance of `Helius` with an asynchronous Solana client
+    /// and a commitment config
+    ///
+    /// # Arguments
+    /// * `api_key` - The API key required for authenticating the requests made
+    /// * `cluster` - The Solana cluster (Devnet or MainnetBeta) that defines the given network environment
+    /// * `commitment` - The commitment level to use for the asynchronous Solana client
+    ///
+    /// # Returns
+    /// An instance of `Helius` if successful. A `HeliusError` is returned if an error occurs during configuration or initialization of the HTTP or RPC client
+    ///
+    /// # Example
+    /// ```rust
+    /// use helius::Helius;
+    /// use helius::types::Cluster;
+    ///
+    /// let helius = Helius::new_with_async_solana_and_commitment("your_api_key", Cluster::Devnet, CommitmentConfig::confirmed()).expect("Failed to create a Helius client");
+    /// ```
+    ///
+    pub fn new_with_async_solana_and_commitment(
+        api_key: &str,
+        cluster: Cluster,
+        commitment: CommitmentConfig,
+    ) -> Result<Self> {
+        let config: Arc<Config> = Arc::new(Config::new(api_key, cluster)?);
+        let client: Client = Client::builder().build().map_err(HeliusError::ReqwestError)?;
+        let url: String = format!("{}/?api-key={}", config.endpoints.rpc, config.api_key);
+        let async_solana_client: Arc<AsyncSolanaRpcClient> =
+            Arc::new(AsyncSolanaRpcClient::new_with_commitment(url, commitment));
+
+        Ok(Helius {
+            config: config.clone(),
+            client: client.clone(),
+            rpc_client: Arc::new(RpcClient::new_with_commitment(
+                Arc::new(client),
+                config.clone(),
+                commitment,
+            )?),
             async_rpc_client: Some(async_solana_client),
             ws_client: None,
         })

--- a/src/rpc_client.rs
+++ b/src/rpc_client.rs
@@ -34,6 +34,7 @@ use reqwest::{Client, Method, Url};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use solana_client::rpc_client::RpcClient as SolanaRpcClient;
+use solana_commitment_config::CommitmentConfig;
 
 pub struct RpcClient {
     pub handler: RequestHandler,
@@ -57,6 +58,30 @@ impl RpcClient {
         let handler: RequestHandler = RequestHandler::new(client)?;
         let url: String = format!("{}/?api-key={}", config.endpoints.rpc, config.api_key);
         let solana_client: Arc<SolanaRpcClient> = Arc::new(SolanaRpcClient::new(url));
+
+        Ok(RpcClient {
+            handler,
+            config,
+            solana_client,
+        })
+    }
+
+    /// Initializes a new RpcClient instance with an embedded Solana client and a commitment config
+    ///
+    /// # Arguments
+    /// * `client` - Shared HTTP client for making requests
+    /// * `config` - Configuration holding a given API key and endpoint URLs
+    /// * `commitment` - Commitment level to use for the Solana client
+    ///
+    /// # Returns
+    /// A result that, if successful, contains the initialized RpcClient
+    ///
+    /// # Errors
+    /// Returns `HeliusError` if the URL isn't formatted correctly or the `RequestHandler` fails to initialize
+    pub fn new_with_commitment(client: Arc<Client>, config: Arc<Config>, commitment: CommitmentConfig) -> Result<Self> {
+        let handler: RequestHandler = RequestHandler::new(client)?;
+        let url: String = format!("{}/?api-key={}", config.endpoints.rpc, config.api_key);
+        let solana_client: Arc<SolanaRpcClient> = Arc::new(SolanaRpcClient::new_with_commitment(url, commitment));
 
         Ok(RpcClient {
             handler,

--- a/tests/test_client.rs
+++ b/tests/test_client.rs
@@ -1,6 +1,7 @@
 use helius::client::Helius;
 use helius::error::Result;
 use helius::types::Cluster;
+use solana_commitment_config::CommitmentConfig;
 
 #[test]
 fn test_creating_new_client_success() {
@@ -25,4 +26,24 @@ fn test_creating_new_async_client_success() {
     let helius: Helius = result.unwrap();
     assert_eq!(helius.config.api_key, api_key);
     assert!(helius.async_rpc_client.is_some());
+}
+
+#[test]
+fn test_creating_new_client_with_commitment_success() {
+    let api_key: &str = "valid-api-key";
+    let cluster: Cluster = Cluster::Devnet;
+    let commitment: CommitmentConfig = CommitmentConfig::confirmed();
+
+    let result: Result<Helius> = Helius::new_with_commitment(api_key, cluster, commitment);
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_creating_new_async_client_with_commitment_success() {
+    let api_key: &str = "valid-api-key";
+    let cluster: Cluster = Cluster::Devnet;
+    let commitment: CommitmentConfig = CommitmentConfig::confirmed();
+
+    let result: Result<Helius> = Helius::new_with_async_solana_and_commitment(api_key, cluster, commitment);
+    assert!(result.is_ok());
 }


### PR DESCRIPTION
### Changes

  - Adds support for creating Solana RPC clients (sync/async) with a specified commitment level
  - Adds solana-commitment-config dependency to support commitment level configuration
  - Updates RpcClient to support commitment configuration via new_with_commitment()

### Motivation

  - The default commitment level when using ::new() is finalized, which is prohibitive for use cases requiring faster confirmation (e.g., confirmed commitment)

### API Changes

  New Methods Added:
  - Helius::new_with_commitment(api_key, cluster, commitment) - Creates sync client with custom commitment
  - Helius::new_with_async_solana_and_commitment(api_key, cluster, commitment) - Creates async client with custom commitment
  - RpcClient::new_with_commitment(client, config, commitment) - Internal RPC client with commitment support
