### PR TITLE
feat(optimized_transaction): Add CU Buffer Multiplier

### DIFF
--- a/examples/send_smart_transaction_with_seeds.rs
+++ b/examples/send_smart_transaction_with_seeds.rs
@@ -56,6 +56,7 @@ async fn main() {
             fee_payer_seed: None,
             lookup_tables: Some(address_lut),
             priority_fee_cap: Some(100000),
+            cu_buffer_multiplier: None,
         };
 
         // Configure send options (optional)

--- a/examples/send_smart_transaction_with_tip.rs
+++ b/examples/send_smart_transaction_with_tip.rs
@@ -33,6 +33,7 @@ async fn main() {
         lookup_tables: None,
         fee_payer: None,
         priority_fee_cap: None,
+        cu_buffer_multiplier: None,
     };
 
     let config: SmartTransactionConfig = SmartTransactionConfig {

--- a/src/optimized_transaction.rs
+++ b/src/optimized_transaction.rs
@@ -385,8 +385,9 @@ impl Helius {
             ));
         }
 
-        // Default to 200k CUs if sim fails
-        let compute_units: u64 = if let Some(u) = units { u } else { 200_000u64 };
+        let compute_units: u64 = units.ok_or(HeliusError::InvalidInput(
+            "Error fetching compute units for the instructions provided".to_string(),
+        ))?;
 
         let multiplier: f32 = config.cu_buffer_multiplier.unwrap_or(CU_BUFFER_MULTIPLIER_DEFAULT);
 
@@ -695,8 +696,9 @@ impl Helius {
             )
             .await?;
 
-        // Default to 200k CUs if sim fails
-        let compute_units: u64 = if let Some(u) = units { u } else { 200_000u64 };
+        let compute_units: u64 = units.ok_or(HeliusError::InvalidInput(
+            "Error fetching compute units for the instructions provided".to_string(),
+        ))?;
 
         let multiplier: f32 = create_config
             .cu_buffer_multiplier
@@ -908,8 +910,9 @@ impl Helius {
             ));
         }
 
-        // Default to 200k CUs if sim fails
-        let compute_units: u64 = if let Some(u) = units { u } else { 200_000u64 };
+        let compute_units: u64 = units.ok_or(HeliusError::InvalidInput(
+            "Error fetching compute units for the instructions provided".to_string(),
+        ))?;
 
         let multiplier: f32 = config.cu_buffer_multiplier.unwrap_or(CU_BUFFER_MULTIPLIER_DEFAULT);
 

--- a/src/optimized_transaction.rs
+++ b/src/optimized_transaction.rs
@@ -386,11 +386,7 @@ impl Helius {
         }
 
         // Default to 200k CUs if sim fails
-        let compute_units: u64 = if let Some(u) = units {
-            u
-        } else {
-            200_000u64
-        };
+        let compute_units: u64 = if let Some(u) = units { u } else { 200_000u64 };
 
         let multiplier: f32 = config.cu_buffer_multiplier.unwrap_or(CU_BUFFER_MULTIPLIER_DEFAULT);
 
@@ -700,13 +696,11 @@ impl Helius {
             .await?;
 
         // Default to 200k CUs if sim fails
-        let compute_units: u64 = if let Some(u) = units {
-            u
-        } else {
-            200_000u64
-        };
+        let compute_units: u64 = if let Some(u) = units { u } else { 200_000u64 };
 
-        let multiplier: f32 = create_config.cu_buffer_multiplier.unwrap_or(CU_BUFFER_MULTIPLIER_DEFAULT);
+        let multiplier: f32 = create_config
+            .cu_buffer_multiplier
+            .unwrap_or(CU_BUFFER_MULTIPLIER_DEFAULT);
 
         let customers_cu: u32 = if compute_units < 1000 {
             1000
@@ -915,11 +909,7 @@ impl Helius {
         }
 
         // Default to 200k CUs if sim fails
-        let compute_units: u64 = if let Some(u) = units {
-            u
-        } else {
-            200_000u64
-        };
+        let compute_units: u64 = if let Some(u) = units { u } else { 200_000u64 };
 
         let multiplier: f32 = config.cu_buffer_multiplier.unwrap_or(CU_BUFFER_MULTIPLIER_DEFAULT);
 

--- a/src/optimized_transaction.rs
+++ b/src/optimized_transaction.rs
@@ -38,6 +38,8 @@ use solana_transaction_status::TransactionConfirmationStatus;
 use std::time::{Duration, Instant};
 use tokio::time::sleep;
 
+const CU_BUFFER_MULTIPLIER_DEFAULT: f32 = 1.25;
+
 const MIN_TIP_LAMPORTS_DUAL: u64 = 1_000_000; // 0.001 SOL
 const MIN_TIP_LAMPORTS_SWQOS: u64 = 500_000; // 0.0005 SOL
 
@@ -383,11 +385,19 @@ impl Helius {
             ));
         }
 
-        let compute_units: u64 = units.unwrap();
+        // Default to 200k CUs if sim fails
+        let compute_units: u64 = if let Some(u) = units {
+            u
+        } else {
+            200_000u64
+        };
+
+        let multiplier: f32 = config.cu_buffer_multiplier.unwrap_or(CU_BUFFER_MULTIPLIER_DEFAULT);
+
         let customers_cu: u32 = if compute_units < 1000 {
             1000
         } else {
-            (compute_units as f64 * 1.1).ceil() as u32
+            (compute_units as f64 * multiplier as f64).ceil() as u32
         };
 
         // Add the compute unit limit instruction with a margin
@@ -689,14 +699,19 @@ impl Helius {
             )
             .await?;
 
-        let compute_units: u64 = units.ok_or(HeliusError::InvalidInput(
-            "Error fetching compute units for the instructions provided".to_string(),
-        ))?;
+        // Default to 200k CUs if sim fails
+        let compute_units: u64 = if let Some(u) = units {
+            u
+        } else {
+            200_000u64
+        };
+
+        let multiplier: f32 = create_config.cu_buffer_multiplier.unwrap_or(CU_BUFFER_MULTIPLIER_DEFAULT);
 
         let customers_cu: u32 = if compute_units < 1000 {
             1000
         } else {
-            (compute_units as f64 * 1.1).ceil() as u32
+            (compute_units as f64 * multiplier as f64).ceil() as u32
         };
 
         final_instructions.push(ComputeBudgetInstruction::set_compute_unit_limit(customers_cu));
@@ -899,11 +914,19 @@ impl Helius {
             ));
         }
 
-        let compute_units = units.unwrap();
+        // Default to 200k CUs if sim fails
+        let compute_units: u64 = if let Some(u) = units {
+            u
+        } else {
+            200_000u64
+        };
+
+        let multiplier: f32 = config.cu_buffer_multiplier.unwrap_or(CU_BUFFER_MULTIPLIER_DEFAULT);
+
         let customers_cu: u32 = if compute_units < 1000 {
             1000
         } else {
-            (compute_units as f64 * 1.1).ceil() as u32
+            (compute_units as f64 * multiplier as f64).ceil() as u32
         };
 
         // Add the compute unit limit ix at the start

--- a/src/types/inner.rs
+++ b/src/types/inner.rs
@@ -911,6 +911,20 @@ pub struct CreateSmartTransactionConfig {
     pub lookup_tables: Option<Vec<AddressLookupTableAccount>>,
     pub fee_payer: Option<Arc<dyn Signer>>,
     pub priority_fee_cap: Option<u64>,
+    pub cu_buffer_multiplier: Option<f32>,
+}
+
+impl Default for CreateSmartTransactionConfig {
+    fn default() -> Self {
+        Self {
+            instructions: Vec::new(),
+            signers: Vec::new(),
+            lookup_tables: None,
+            fee_payer: None,
+            priority_fee_cap: None,
+            cu_buffer_multiplier: Some(1.25),
+        }
+    }
 }
 
 impl CreateSmartTransactionConfig {
@@ -921,6 +935,7 @@ impl CreateSmartTransactionConfig {
             lookup_tables: None,
             fee_payer: None,
             priority_fee_cap: None,
+            cu_buffer_multiplier: None,
         }
     }
 }
@@ -974,6 +989,20 @@ pub struct CreateSmartTransactionSeedConfig {
     pub fee_payer_seed: Option<[u8; 32]>,
     pub lookup_tables: Option<Vec<AddressLookupTableAccount>>,
     pub priority_fee_cap: Option<u64>,
+    pub cu_buffer_multiplier: Option<f32>,
+}
+
+impl Default for CreateSmartTransactionSeedConfig {
+    fn default() -> Self {
+        Self {
+            instructions: Vec::new(),
+            signer_seeds: Vec::new(),
+            fee_payer_seed: None,
+            lookup_tables: None,
+            priority_fee_cap: None,
+            cu_buffer_multiplier: Some(1.25),
+        }
+    }
 }
 
 impl CreateSmartTransactionSeedConfig {
@@ -984,6 +1013,7 @@ impl CreateSmartTransactionSeedConfig {
             fee_payer_seed: None,
             lookup_tables: None,
             priority_fee_cap: None,
+            cu_buffer_multiplier: None,
         }
     }
 


### PR DESCRIPTION
This PR aims to help resolve #137 by introducing a new `cu_buffer_multiplier` field to the smart transaction creation step. Now, users can update the buffer added to their CU estimation to avoid instances of CU exhaustion. For safety purposes, the buffer's default has been increased from 1.1x to 1.25x