### PR TITLE
fix(workflow): Add `rustfmt` Component

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,7 +53,7 @@ jobs:
         toolchain: stable
         profile: minimal
         override: true
-        components: clippy
+        components: clippy, rustfmt
 
     - name: Install Protobuf Compiler
       run: sudo apt-get update && sudo apt-get install -y protobuf-compiler


### PR DESCRIPTION
Currently, the workflow defined in `rust.yml` uses `profile: minimal`, which doesn't include `rustfmt`. This PR aims to add `rustfmt` so we install it before the formatting check runs