### PR TITLE
feat(client): Migrate Client Creation to a Builder Pattern

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helius"
-version = "0.5.1"
+version = "1.0.0"
 rust-version = "1.85.1"
 edition = "2021"
 description = "An asynchronous Helius Rust SDK for building the future of Solana"

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,123 @@
+# Migration Guide: 0.x to 1.0
+
+This guide covers the breaking changes in the Helius Rust SDK 1.0 release and how to update your code.
+
+## Summary of Changes
+
+- **Simplified constructors**: 6 constructors replaced with 3 (`new`, `new_async`, `new_with_url`)
+- **New `HeliusBuilder`**: Builder pattern for advanced configuration
+- **Custom URL support**: Use any RPC endpoint without an API key
+- **`Config.api_key` is now `Option<ApiKey>`**: Type-safe API key with validation
+- **`new()` is still synchronous**: No `.await` needed for basic clients
+- **`new_async()` is async**: Only the WebSocket constructor requires `.await`
+
+## Constructor Changes
+
+### `Helius::new()` — unchanged signature, still sync
+
+```rust
+// Before (0.x)
+let helius = Helius::new("api-key", Cluster::MainnetBeta)?;
+
+// After (1.0) — same!
+let helius = Helius::new("api-key", Cluster::MainnetBeta)?;
+```
+
+### Removed constructors — use `HeliusBuilder` instead
+
+| Removed Constructor | Replacement |
+|---|---|
+| `new_with_commitment(key, cluster, commitment)` | `HeliusBuilder::new().with_api_key(key)?.with_cluster(cluster).with_commitment(commitment).build().await?` |
+| `new_with_async_solana(key, cluster)` | `HeliusBuilder::new().with_api_key(key)?.with_cluster(cluster).with_async_solana().build().await?` |
+| `new_with_async_solana_and_commitment(key, cluster, commitment)` | `HeliusBuilder::new().with_api_key(key)?.with_cluster(cluster).with_async_solana().with_commitment(commitment).build().await?` |
+| `new_with_ws(key, cluster)` | `Helius::new_async(key, cluster).await?` |
+| `new_with_ws_with_timeouts(key, cluster, ping, pong)` | `HeliusBuilder::new().with_api_key(key)?.with_cluster(cluster).with_websocket(ping, pong).build().await?` |
+
+### New constructors
+
+```rust
+// Full-featured: async Solana + WebSocket + confirmed commitment (async)
+let helius = Helius::new_async("api-key", Cluster::MainnetBeta).await?;
+
+// Custom URL, no API key required (sync)
+let helius = Helius::new_with_url("http://localhost:8899")?;
+```
+
+## Config Struct Changes
+
+The `Config` struct has two new fields:
+
+```rust
+// Before (0.x)
+let config = Config {
+    api_key: "my-key".to_string(),
+    cluster: Cluster::Devnet,
+    endpoints: HeliusEndpoints::for_cluster(&Cluster::Devnet),
+};
+
+// After (1.0)
+use helius::types::ApiKey;
+
+let config = Config {
+    api_key: Some(ApiKey::new("my-key")?),
+    cluster: Cluster::Devnet,
+    endpoints: HeliusEndpoints::for_cluster(&Cluster::Devnet),
+    custom_url: None,  // new field
+};
+```
+
+### Accessing the API key
+
+```rust
+// Before (0.x)
+let key: &str = &config.api_key;
+
+// After (1.0)
+let key: &str = config.api_key.as_ref().unwrap().as_str();
+
+// Or use the helper method
+if config.has_api_key() {
+    let key = config.require_api_key("my feature")?;
+}
+```
+
+## HeliusBuilder (New)
+
+The builder provides fine-grained control over client configuration:
+
+```rust
+use helius::HeliusBuilder;
+use helius::types::Cluster;
+use solana_commitment_config::CommitmentConfig;
+
+let helius = HeliusBuilder::new()
+    .with_api_key("your-key")?
+    .with_cluster(Cluster::MainnetBeta)
+    .with_async_solana()
+    .with_commitment(CommitmentConfig::confirmed())
+    .with_websocket(Some(5), Some(15))  // custom ping/pong
+    .build()
+    .await?;
+```
+
+### Custom URL with builder
+
+```rust
+let helius = HeliusBuilder::new()
+    .with_custom_url("https://my-rpc-provider.com/")?
+    .with_custom_api_url("https://api.example.com/")?  // optional separate API endpoint
+    .with_api_key("optional-key")?
+    .build()
+    .await?;
+```
+
+## Quick Find-and-Replace
+
+For most codebases, these replacements will cover the migration:
+
+| Find | Replace |
+|---|---|
+| `Helius::new_with_ws(key, cluster).await?` | `Helius::new_async(key, cluster).await?` |
+| `Helius::new_with_async_solana(key, cluster)?` | `HeliusBuilder::new().with_api_key(key)?.with_cluster(cluster).with_async_solana().build().await?` |
+| `api_key: "key".to_string()` (in Config) | `api_key: Some(ApiKey::new("key")?)` |
+| `config.api_key` (as &str) | `config.api_key.as_ref().unwrap().as_str()` |

--- a/README.md
+++ b/README.md
@@ -32,20 +32,30 @@ helius = { version = "x.y.z", default-features = false, features = ["rustls"] }
 Using `rustls` may be preferred in environments where OpenSSL is not available or when a pure Rust TLS implementation is desired. However, it may not support all the same features as the native TLS implementation
 
 ## Usage
-### `Helius`
-The SDK provides a [`Helius`](https://github.com/helius-labs/helius-rust-sdk/blob/dev/src/client.rs) instance that can be configured with an API key and a given Solana cluster. Developers can generate a new API key on the [Helius Developer Dashboard](https://dev.helius.xyz/dashboard/app). This instance acts as the main entry point for interacting with the SDK by providing methods to access different Solana and RPC client functionalities. The following code is an example of how to use the SDK to fetch info on [Mad Lad #8420](https://explorer.solana.com/address/F9Lw3ki3hJ7PF9HQXsBzoY8GyE6sPoEZZdXJBsTTD2rk?network=mainnet):
+### Quick Start
+The SDK provides a [`Helius`](https://github.com/helius-labs/helius-rust-sdk/blob/dev/src/client.rs) instance that can be configured with an API key and a given Solana cluster. Developers can generate a new API key on the [Helius Developer Dashboard](https://dev.helius.xyz/dashboard/app). This instance acts as the main entry point for interacting with the SDK by providing methods to access different Solana and RPC client functionalities.
+
+There are three simple constructors and a builder for advanced configuration:
+
+| Constructor | Use Case |
+|---|---|
+| `Helius::new(api_key, cluster)` | Basic RPC operations with Helius endpoints |
+| `Helius::new_async(api_key, cluster)` | Full-featured: async Solana client + WebSocket + confirmed commitment |
+| `Helius::new_with_url(url)` | Custom RPC endpoint (no API key required) |
+| `HeliusBuilder::new()` | Advanced configuration (custom timeouts, TLS, etc.) |
+
+### `Helius::new()` — Basic Client
+The simplest way to get started. Creates a client for standard Helius RPC operations. This constructor is **synchronous**:
 ```rust
+use helius::Helius;
 use helius::error::Result;
-use helius::types::{Cluster, DisplayOptions, GetAssetRequest, GetAssetResponseForAsset};
+use helius::types::{Cluster, GetAssetRequest, GetAssetResponseForAsset};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let api_key: &str = "YOUR_API_KEY";
-    let cluster: Cluster = Cluster::MainnetBeta;
+    let helius = Helius::new("YOUR_API_KEY", Cluster::MainnetBeta)?;
 
-    let helius: Helius = Helius::new(api_key, cluster).unwrap();
-
-    let request: GetAssetRequest = GetAssetRequest {
+    let request = GetAssetRequest {
         id: "F9Lw3ki3hJ7PF9HQXsBzoY8GyE6sPoEZZdXJBsTTD2rk".to_string(),
         display_options: None,
     };
@@ -53,9 +63,7 @@ async fn main() -> Result<()> {
     let response: Result<Option<GetAssetResponseForAsset>> = helius.rpc().get_asset(request).await;
 
     match response {
-        Ok(Some(asset)) => {
-            println!("Asset: {:?}", asset);
-        },
+        Ok(Some(asset)) => println!("Asset: {:?}", asset),
         Ok(None) => println!("No asset found."),
         Err(e) => println!("Error retrieving asset: {:?}", e),
     }
@@ -63,6 +71,89 @@ async fn main() -> Result<()> {
     Ok(())
 }
 ```
+
+### `Helius::new_async()` — Full-Featured Client
+The recommended constructor for production applications. Includes async Solana RPC, WebSocket streaming, and confirmed commitment level:
+```rust
+use helius::Helius;
+use helius::types::Cluster;
+
+#[tokio::main]
+async fn main() {
+    let helius = Helius::new_async("YOUR_API_KEY", Cluster::MainnetBeta)
+        .await
+        .expect("Failed to create client");
+
+    // Async Solana RPC
+    let async_client = helius.async_connection().expect("Async client available");
+
+    // Enhanced WebSocket streaming
+    let ws = helius.ws().expect("WebSocket available");
+}
+```
+
+### `Helius::new_with_url()` — Custom RPC Endpoint
+Use your own RPC node, a third-party provider, or localhost for development. No API key required. This constructor is **synchronous**:
+```rust
+use helius::Helius;
+
+fn main() {
+    // Custom RPC provider
+    let helius = Helius::new_with_url("https://my-rpc-provider.com/")
+        .expect("Failed to create client");
+
+    // Local development
+    let local = Helius::new_with_url("http://localhost:8899")
+        .expect("Failed to create client");
+}
+```
+
+### `HeliusBuilder` — Advanced Configuration
+For fine-grained control over the client configuration, use the builder pattern:
+```rust
+use helius::HeliusBuilder;
+use helius::types::Cluster;
+use solana_commitment_config::CommitmentConfig;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() {
+    // Custom RPC with API key and specific commitment
+    let helius = HeliusBuilder::new()
+        .with_api_key("YOUR_API_KEY").unwrap()
+        .with_cluster(Cluster::MainnetBeta)
+        .with_async_solana()
+        .with_commitment(CommitmentConfig::confirmed())
+        .build()
+        .await
+        .expect("Failed to build client");
+
+    // Custom URL with separate API and RPC endpoints
+    let helius = HeliusBuilder::new()
+        .with_custom_url("https://rpc.example.com/").unwrap()
+        .with_custom_api_url("https://api.example.com/").unwrap()
+        .with_api_key("optional-key").unwrap()
+        .build()
+        .await
+        .expect("Failed to build client");
+
+    // Custom HTTP client with timeouts
+    let http_client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()
+        .unwrap();
+
+    let helius = HeliusBuilder::new()
+        .with_api_key("YOUR_API_KEY").unwrap()
+        .with_cluster(Cluster::MainnetBeta)
+        .with_http_client(http_client)
+        .with_websocket(Some(5), Some(15)) // custom ping/pong timeouts
+        .build()
+        .await
+        .expect("Failed to build client");
+}
+```
+
 ### `HeliusFactory`
 The SDK also comes equipped with `HeliusFactory`, a factory for creating instances of `Helius`. This factory allows for a centralized configuration and creation of `Helius` clients so work can be done across multiple clusters at the same time. Using a factory simplifies client code and enhances maintainability by ensuring that all `Helius` clients are configured consistently. It has the following functionality:
 - A [`new` method](https://github.com/helius-labs/helius-rust-sdk/blob/a79a751e1a064125010bdb359068a366d635d005/src/factory.rs#L21-L36) used to create a new `HeliusFactory` capable of producing `Helius` clients. Note this method does not create a `reqwest` client
@@ -72,10 +163,10 @@ The SDK also comes equipped with `HeliusFactory`, a factory for creating instanc
 ### Embedded Solana Client
 The `Helius` client has an embedded [Solana client](https://docs.rs/solana-client/latest/solana_client/rpc_client/struct.RpcClient.html) that can be accessed via `helius.connection().request_name()` where `request_name()` is a given [RPC method](https://docs.rs/solana-client/latest/solana_client/rpc_client/struct.RpcClient.html#implementations). A full list of all Solana RPC HTTP methods can be found [here](https://solana.com/docs/rpc/http).
 
-Note that this Solana client is synchronous by default. An asynchronous client can be created using the `new_with_async_solana` method in place of the `new` method. The asynchronous client can be accessed via `helius.async_connection()?.some_async_method().await?` where `some_async_method()` is a given async RPC method.
+For asynchronous operations, use `Helius::new_async()` or `HeliusBuilder` with `.with_async_solana()`. The async client can be accessed via `helius.async_connection()?.some_async_method().await?` where `some_async_method()` is a given async RPC method.
 
 ### Enhanced WebSockets
-The `Helius` client can also be created with the `new_with_ws()` method in place of the `new` method. This will create a WebSocket client, adding support for the [Geyser Enhanced WebSocket methods](https://docs.helius.dev/webhooks-and-websockets/websockets#helius-geyser-enhanced-websockets-beta) [`transactionSubscribe`](https://docs.helius.dev/webhooks-and-websockets/websockets#transaction-subscribe) and [`accountSubscribe`](https://docs.helius.dev/webhooks-and-websockets/websockets#account-subscribe)
+Use `Helius::new_async()` or `HeliusBuilder` with `.with_websocket(None, None)` to create a client with WebSocket support. This enables the [Geyser Enhanced WebSocket methods](https://docs.helius.dev/webhooks-and-websockets/websockets#helius-geyser-enhanced-websockets-beta) [`transactionSubscribe`](https://docs.helius.dev/webhooks-and-websockets/websockets#transaction-subscribe) and [`accountSubscribe`](https://docs.helius.dev/webhooks-and-websockets/websockets#account-subscribe)
 
 ### Examples
 More examples of how to use the SDK can be found in the [`examples`](https://github.com/helius-labs/helius-rust-sdk/tree/dev/examples) directory.
@@ -166,3 +257,6 @@ Note that these methods have been deprecated, and will be removed in a future re
 - [`deserialize_str_to_number`](https://github.com/helius-labs/helius-rust-sdk/blob/dev/src/utils/deserialize_str_to_number.rs) - Deserializes a `String` to a `Number`
 - [`is_valid_solana_address`](https://github.com/helius-labs/helius-rust-sdk/blob/dev/src/utils/is_valid_solana_address.rs) - Returns whether a given string slice is a valid Solana address
 - [`make_keypairs`](https://github.com/helius-labs/helius-rust-sdk/blob/dev/src/utils/make_keypairs.rs) - Generates a specified number of keypairs
+
+## Migrating from 0.x
+If you're upgrading from 0.x, see the [Migration Guide](MIGRATION.md) for details on breaking changes and how to update your code.

--- a/examples/enhanced_websocket_accounts.rs
+++ b/examples/enhanced_websocket_accounts.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<()> {
     let api_key: &str = "your_api_key";
     let cluster: Cluster = Cluster::MainnetBeta;
 
-    let helius: Helius = Helius::new_with_ws(api_key, cluster).await?;
+    let helius: Helius = Helius::new_async(api_key, cluster).await?;
 
     let key: pubkey::Pubkey = pubkey!("BtsmiEEvnSuUnKxqXj2PZRYpPJAc7C34mGz8gtJ1DAaH");
 

--- a/examples/enhanced_websocket_transactions.rs
+++ b/examples/enhanced_websocket_transactions.rs
@@ -1,6 +1,6 @@
 use helius::error::Result;
 use helius::types::{Cluster, RpcTransactionsConfig, TransactionSubscribeFilter, TransactionSubscribeOptions};
-use helius::Helius;
+use helius::{Helius, HeliusBuilder};
 use solana_sdk::pubkey;
 use tokio_stream::StreamExt;
 
@@ -10,7 +10,12 @@ async fn main() -> Result<()> {
     let cluster: Cluster = Cluster::MainnetBeta;
 
     // Uses custom ping-pong timeouts to ping every 15s and timeout after 45s of no pong
-    let helius: Helius = Helius::new_with_ws_with_timeouts(api_key, cluster, Some(15), Some(45)).await?;
+    let helius: Helius = HeliusBuilder::new()
+        .with_api_key(api_key)?
+        .with_cluster(cluster)
+        .with_websocket(Some(15), Some(45))
+        .build()
+        .await?;
 
     let key: pubkey::Pubkey = pubkey!("BtsmiEEvnSuUnKxqXj2PZRYpPJAc7C34mGz8gtJ1DAaH");
 

--- a/examples/get_latest_blockhash_async.rs
+++ b/examples/get_latest_blockhash_async.rs
@@ -9,7 +9,9 @@ async fn main() -> Result<()> {
     let api_key: &str = "your_api_key";
     let cluster: Cluster = Cluster::MainnetBeta;
 
-    let helius: Helius = Helius::new_async(api_key, cluster).await.expect("Failed to create a Helius client");
+    let helius: Helius = Helius::new_async(api_key, cluster)
+        .await
+        .expect("Failed to create a Helius client");
 
     let latest_blockhash: Hash = helius.async_connection()?.get_latest_blockhash().await?;
     println!("{:?}", latest_blockhash);

--- a/examples/get_latest_blockhash_async.rs
+++ b/examples/get_latest_blockhash_async.rs
@@ -9,7 +9,7 @@ async fn main() -> Result<()> {
     let api_key: &str = "your_api_key";
     let cluster: Cluster = Cluster::MainnetBeta;
 
-    let helius: Helius = Helius::new_with_async_solana(api_key, cluster).expect("Failed to create a Helius client");
+    let helius: Helius = Helius::new_async(api_key, cluster).await.expect("Failed to create a Helius client");
 
     let latest_blockhash: Hash = helius.async_connection()?.get_latest_blockhash().await?;
     println!("{:?}", latest_blockhash);

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,400 @@
+use crate::config::Config;
+use crate::error::{HeliusError, Result};
+use crate::types::{validate_rpc_url, validate_ws_url, ApiKey, Cluster, HeliusEndpoints};
+use crate::websocket::EnhancedWebsocket;
+use crate::Helius;
+use reqwest::Client;
+use solana_client::nonblocking::rpc_client::RpcClient as AsyncSolanaRpcClient;
+use solana_commitment_config::CommitmentConfig;
+use std::sync::Arc;
+use url::Url;
+
+/// Builder for creating Helius client instances with flexible configuration.
+///
+/// The builder pattern provides a clean, type-safe way to configure the Helius
+/// client with various options including custom RPC endpoints, optional API keys,
+/// async Solana clients, WebSocket support, and more.
+///
+/// # Examples
+///
+/// ## Standard Helius Endpoint
+/// ```ignore
+/// use helius::{HeliusBuilder, Cluster};
+///
+/// let helius = HeliusBuilder::new()
+///     .with_api_key("your-api-key")?
+///     .with_cluster(Cluster::MainnetBeta)
+///     .build()
+///     .await?;
+/// ```
+///
+/// ## Custom RPC Endpoint
+/// ```ignore
+/// let helius = HeliusBuilder::new()
+///     .with_custom_url("https://my-rpc-provider.com/")?
+///     .with_api_key("optional-key")?
+///     .build()
+///     .await?;
+/// ```
+///
+/// ## Development with Localhost
+/// ```ignore
+/// let helius = HeliusBuilder::new()
+///     .with_custom_url("http://localhost:8899")?
+///     .build()
+///     .await?;
+/// ```
+///
+/// ## Full-Featured Setup
+/// ```ignore
+/// let helius = HeliusBuilder::new()
+///     .with_api_key("your-api-key")?
+///     .with_cluster(Cluster::MainnetBeta)
+///     .with_async_solana()
+///     .with_websocket(None, None)
+///     .with_commitment(CommitmentConfig::confirmed())
+///     .build()
+///     .await?;
+/// ```
+#[derive(Default)]
+pub struct HeliusBuilder {
+    api_key: Option<ApiKey>,
+    cluster: Option<Cluster>,
+    custom_rpc_url: Option<Url>,
+    custom_api_url: Option<Url>,
+    custom_ws_url: Option<Url>,
+    commitment: Option<CommitmentConfig>,
+    http_client: Option<Client>,
+    enable_async: bool,
+    ws_config: Option<(Option<u64>, Option<u64>)>, // (ping_interval, pong_timeout)
+}
+
+impl HeliusBuilder {
+    /// Creates a new builder with default settings.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the API key for authentication.
+    ///
+    /// Required for:
+    /// - Helius-hosted endpoints
+    /// - Webhook operations
+    /// - Enhanced transaction parsing
+    ///
+    /// Optional for custom RPC endpoints.
+    ///
+    /// # Errors
+    /// Returns error if the API key is empty or whitespace-only.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// HeliusBuilder::new()
+    ///     .with_api_key("your-api-key")?
+    /// ```
+    pub fn with_api_key(mut self, key: impl Into<String>) -> Result<Self> {
+        self.api_key = Some(ApiKey::new(key)?);
+        Ok(self)
+    }
+
+    /// Sets the Solana cluster (Devnet, MainnetBeta, or StakedMainnetBeta).
+    ///
+    /// Only used when connecting to Helius-hosted endpoints.
+    /// Ignored when using custom URLs.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use helius::types::Cluster;
+    ///
+    /// HeliusBuilder::new()
+    ///     .with_cluster(Cluster::MainnetBeta)
+    /// ```
+    pub fn with_cluster(mut self, cluster: Cluster) -> Self {
+        self.cluster = Some(cluster);
+        self
+    }
+
+    /// Sets a custom RPC URL instead of using Helius-hosted endpoints.
+    ///
+    /// This allows you to:
+    /// - Use your own RPC node
+    /// - Connect through a proxy
+    /// - Point to localhost for development
+    /// - Use third-party RPC providers
+    ///
+    /// # Security
+    /// - Only http:// and https:// schemes are allowed
+    /// - Credentials in URLs are rejected (use `with_api_key()` instead)
+    /// - Localhost is allowed (useful for development)
+    ///
+    /// # Arguments
+    /// * `url` - The custom RPC endpoint URL
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Production custom RPC
+    /// builder.with_custom_url("https://my-rpc-provider.com/")?;
+    ///
+    /// // Local development
+    /// builder.with_custom_url("http://localhost:8899")?;
+    /// ```
+    pub fn with_custom_url(mut self, url: impl AsRef<str>) -> Result<Self> {
+        let validated = validate_rpc_url(url.as_ref())?;
+        self.custom_rpc_url = Some(validated.clone());
+
+        // Default API URL to same as RPC URL
+        if self.custom_api_url.is_none() {
+            self.custom_api_url = Some(validated);
+        }
+
+        Ok(self)
+    }
+
+    /// Sets a custom API endpoint URL (separate from RPC).
+    ///
+    /// Use this when your API endpoint differs from your RPC endpoint.
+    /// This is where webhook and enhanced transaction requests are sent.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// builder
+    ///     .with_custom_url("https://rpc.example.com/")?
+    ///     .with_custom_api_url("https://api.example.com/")?;
+    /// ```
+    pub fn with_custom_api_url(mut self, url: impl AsRef<str>) -> Result<Self> {
+        self.custom_api_url = Some(validate_rpc_url(url.as_ref())?);
+        Ok(self)
+    }
+
+    /// Sets a custom WebSocket URL for enhanced transactions.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// builder.with_custom_ws_url("wss://ws.example.com/")?;
+    /// ```
+    pub fn with_custom_ws_url(mut self, url: impl AsRef<str>) -> Result<Self> {
+        self.custom_ws_url = Some(validate_ws_url(url.as_ref())?);
+        Ok(self)
+    }
+
+    /// Sets the commitment level for Solana transactions.
+    ///
+    /// Common values:
+    /// - `CommitmentConfig::processed()` - Fastest, least safe
+    /// - `CommitmentConfig::confirmed()` - Balanced (recommended)
+    /// - `CommitmentConfig::finalized()` - Slowest, most safe
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use solana_commitment_config::CommitmentConfig;
+    ///
+    /// builder.with_commitment(CommitmentConfig::confirmed());
+    /// ```
+    pub fn with_commitment(mut self, commitment: CommitmentConfig) -> Self {
+        self.commitment = Some(commitment);
+        self
+    }
+
+    /// Enables async Solana client support.
+    ///
+    /// Call this to add `async_rpc_client` to the Helius instance.
+    /// Access it via `helius.async_connection()?`.
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let helius = HeliusBuilder::new()
+    ///     .with_api_key("key")?
+    ///     .with_cluster(Cluster::MainnetBeta)
+    ///     .with_async_solana()
+    ///     .build()
+    ///     .await?;
+    ///
+    /// let async_client = helius.async_connection()?;
+    /// ```
+    pub fn with_async_solana(mut self) -> Self {
+        self.enable_async = true;
+        self
+    }
+
+    /// Enables WebSocket support for enhanced transaction streaming.
+    ///
+    /// # Arguments
+    /// * `ping_interval_secs` - Seconds between ping messages (default: 10)
+    /// * `pong_timeout_secs` - Seconds to wait for pong before disconnect (default: 30)
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// // Default timeouts
+    /// builder.with_websocket(None, None);
+    ///
+    /// // Custom timeouts
+    /// builder.with_websocket(Some(5), Some(15));
+    /// ```
+    pub fn with_websocket(
+        mut self,
+        ping_interval_secs: Option<u64>,
+        pong_timeout_secs: Option<u64>
+    ) -> Self {
+        self.ws_config = Some((ping_interval_secs, pong_timeout_secs));
+        self
+    }
+
+    /// Uses a custom reqwest HTTP client.
+    ///
+    /// Useful for configuring:
+    /// - Custom timeouts
+    /// - Proxy settings
+    /// - TLS configuration
+    /// - Connection pooling
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// use std::time::Duration;
+    /// use reqwest::Client;
+    ///
+    /// let client = Client::builder()
+    ///     .timeout(Duration::from_secs(30))
+    ///     .build()?;
+    ///
+    /// builder.with_http_client(client);
+    /// ```
+    pub fn with_http_client(mut self, client: Client) -> Self {
+        self.http_client = Some(client);
+        self
+    }
+
+    /// Builds the Helius client with the configured settings.
+    ///
+    /// # Errors
+    /// - `InvalidInput` if configuration is incomplete or invalid
+    /// - `ReqwestError` if HTTP client creation fails
+    /// - Various errors if WebSocket connection fails (when enabled)
+    ///
+    /// # Examples
+    ///
+    /// ```ignore
+    /// let helius = HeliusBuilder::new()
+    ///     .with_api_key("key")?
+    ///     .with_cluster(Cluster::MainnetBeta)
+    ///     .build()
+    ///     .await?;
+    /// ```
+    pub async fn build(self) -> Result<Helius> {
+        // Build config (doesn't move self anymore since build_config takes &self)
+        let config = self.build_config()?;
+
+        // Now extract fields
+        let custom_ws_url = self.custom_ws_url;
+        let ws_config = self.ws_config;
+        let commitment = self.commitment;
+        let enable_async = self.enable_async;
+        let http_client = self.http_client;
+        let client = http_client
+            .unwrap_or_else(|| Client::builder().build().expect("Failed to build HTTP client"));
+
+        // Build RPC client
+        let rpc_client = if let Some(commitment) = commitment {
+            Arc::new(crate::rpc_client::RpcClient::new_with_commitment(
+                Arc::new(client.clone()),
+                config.clone(),
+                commitment,
+            )?)
+        } else {
+            Arc::new(crate::rpc_client::RpcClient::new(
+                Arc::new(client.clone()),
+                config.clone(),
+            )?)
+        };
+
+        // Build async Solana client if requested
+        let async_rpc_client = if enable_async {
+            let url = config.build_rpc_url();
+            let async_client = if let Some(commitment) = commitment {
+                AsyncSolanaRpcClient::new_with_commitment(url, commitment)
+            } else {
+                AsyncSolanaRpcClient::new(url)
+            };
+            Some(Arc::new(async_client))
+        } else {
+            None
+        };
+
+        // Build WebSocket client if requested
+        let ws_client = if let Some((ping_interval, pong_timeout)) = ws_config {
+            let ws_url = if let Some(custom_ws) = custom_ws_url {
+                custom_ws.to_string()
+            } else {
+                // Requires API key for Helius WebSocket
+                let api_key = config.require_api_key("WebSocket connections")?;
+                EnhancedWebsocket::get_url(&config.cluster, api_key.as_str())?
+            };
+
+            Some(Arc::new(
+                EnhancedWebsocket::new(&ws_url, ping_interval, pong_timeout).await?
+            ))
+        } else {
+            None
+        };
+
+        Ok(Helius {
+            config,
+            client,
+            rpc_client,
+            async_rpc_client,
+            ws_client,
+        })
+    }
+
+    /// Internal: Builds the Config from builder settings.
+    fn build_config(&self) -> Result<Arc<Config>> {
+        // Case 1: Custom URL provided
+        if let Some(ref rpc_url) = self.custom_rpc_url {
+            return Ok(Arc::new(Config {
+                api_key: self.api_key.clone(),
+                cluster: self.cluster.clone().unwrap_or(Cluster::Devnet), // Default for custom URLs
+                endpoints: HeliusEndpoints {
+                    api: self.custom_api_url
+                        .as_ref()
+                        .map(|u| u.to_string())
+                        .unwrap_or_else(|| rpc_url.to_string()),
+                    rpc: rpc_url.to_string(),
+                },
+                custom_url: Some(rpc_url.to_string()),
+            }));
+        }
+
+        // Case 2: Standard Helius endpoints
+        let cluster = self.cluster.clone().ok_or_else(|| {
+            HeliusError::InvalidInput(
+                "Either cluster or custom URL must be specified. \
+                 Use .with_cluster(Cluster::MainnetBeta) or .with_custom_url(\"...\")".to_string()
+            )
+        })?;
+
+        // Warn if no API key for Helius endpoints
+        if self.api_key.is_none() {
+            eprintln!(
+                "⚠️  Warning: No API key provided for Helius endpoint. \
+                 Most features require authentication. Use .with_api_key(\"your-key\")"
+            );
+        }
+
+        let endpoints = HeliusEndpoints::for_cluster(&cluster);
+
+        Ok(Arc::new(Config {
+            api_key: self.api_key.clone(),
+            cluster,
+            endpoints,
+            custom_url: None,
+        }))
+    }
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -238,11 +238,7 @@ impl HeliusBuilder {
     /// // Custom timeouts
     /// builder.with_websocket(Some(5), Some(15));
     /// ```
-    pub fn with_websocket(
-        mut self,
-        ping_interval_secs: Option<u64>,
-        pong_timeout_secs: Option<u64>
-    ) -> Self {
+    pub fn with_websocket(mut self, ping_interval_secs: Option<u64>, pong_timeout_secs: Option<u64>) -> Self {
         self.ws_config = Some((ping_interval_secs, pong_timeout_secs));
         self
     }
@@ -298,8 +294,7 @@ impl HeliusBuilder {
         let commitment = self.commitment;
         let enable_async = self.enable_async;
         let http_client = self.http_client;
-        let client = http_client
-            .unwrap_or_else(|| Client::builder().build().expect("Failed to build HTTP client"));
+        let client = http_client.unwrap_or_else(|| Client::builder().build().expect("Failed to build HTTP client"));
 
         // Build RPC client
         let rpc_client = if let Some(commitment) = commitment {
@@ -339,7 +334,7 @@ impl HeliusBuilder {
             };
 
             Some(Arc::new(
-                EnhancedWebsocket::new(&ws_url, ping_interval, pong_timeout).await?
+                EnhancedWebsocket::new(&ws_url, ping_interval, pong_timeout).await?,
             ))
         } else {
             None
@@ -362,7 +357,8 @@ impl HeliusBuilder {
                 api_key: self.api_key.clone(),
                 cluster: self.cluster.clone().unwrap_or(Cluster::Devnet), // Default for custom URLs
                 endpoints: HeliusEndpoints {
-                    api: self.custom_api_url
+                    api: self
+                        .custom_api_url
                         .as_ref()
                         .map(|u| u.to_string())
                         .unwrap_or_else(|| rpc_url.to_string()),
@@ -376,7 +372,8 @@ impl HeliusBuilder {
         let cluster = self.cluster.clone().ok_or_else(|| {
             HeliusError::InvalidInput(
                 "Either cluster or custom URL must be specified. \
-                 Use .with_cluster(Cluster::MainnetBeta) or .with_custom_url(\"...\")".to_string()
+                 Use .with_cluster(Cluster::MainnetBeta) or .with_custom_url(\"...\")"
+                    .to_string(),
             )
         })?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,7 +3,7 @@ use std::{ops::Deref, sync::Arc};
 use crate::config::Config;
 use crate::error::{HeliusError, Result};
 use crate::rpc_client::RpcClient;
-use crate::types::Cluster;
+use crate::types::{validate_rpc_url, ApiKey, Cluster, HeliusEndpoints};
 use crate::websocket::EnhancedWebsocket;
 
 use reqwest::Client;
@@ -29,26 +29,39 @@ pub struct Helius {
 }
 
 impl Helius {
-    /// Creates a new instance of `Helius` configured with a specific API key and a target cluster
+    /// Creates a basic Helius client for standard RPC operations
+    ///
+    /// This is the simplest way to create a Helius client. It is **synchronous** and does not
+    /// require `.await`. For async Solana operations or WebSocket support, use `new_async()`
+    /// or `HeliusBuilder`.
     ///
     /// # Arguments
     /// * `api_key` - The API key required for authenticating the requests made
     /// * `cluster` - The Solana cluster (Devnet or MainnetBeta) that defines the given network environment
     ///
     /// # Returns
-    /// An instance of `Helius` if successful. A `HeliusError` is returned if an error occurs during configuration or initialization of the HTTP or RPC client
+    /// An instance of `Helius` if successful. A `HeliusError` is returned if an error occurs during configuration or initialization
     ///
     /// # Example
     /// ```rust
-    /// use helius::client::Helius;
+    /// use helius::Helius;
     /// use helius::types::Cluster;
     ///
-    /// let helius = Helius::new("your_api_key", Cluster::Devnet).expect("Failed to create a Helius client");
+    /// let helius = Helius::new("your_api_key", Cluster::Devnet)
+    ///     .expect("Failed to create a Helius client");
     /// ```
     pub fn new(api_key: &str, cluster: Cluster) -> Result<Self> {
-        let config: Arc<Config> = Arc::new(Config::new(api_key, cluster)?);
-        let client: Client = Client::builder().build().map_err(HeliusError::ReqwestError)?;
-        let rpc_client: Arc<RpcClient> = Arc::new(RpcClient::new(Arc::new(client.clone()), config.clone())?);
+        let api_key = ApiKey::new(api_key)?;
+        let endpoints = HeliusEndpoints::for_cluster(&cluster);
+        let config = Arc::new(Config {
+            api_key: Some(api_key),
+            cluster,
+            endpoints,
+            custom_url: None,
+        });
+
+        let client = Client::builder().build().map_err(HeliusError::ReqwestError)?;
+        let rpc_client = Arc::new(RpcClient::new(Arc::new(client.clone()), config.clone())?);
 
         Ok(Helius {
             config,
@@ -59,163 +72,105 @@ impl Helius {
         })
     }
 
-    /// Creates a new instance of `Helius` configured with a specific API key, target cluster, and a commitment config
+    /// Creates a full-featured async Helius client with WebSocket support
+    ///
+    /// This is the recommended constructor for production applications that need:
+    /// - Async Solana RPC operations
+    /// - Enhanced WebSocket transaction streaming
+    /// - Confirmed commitment level
+    ///
+    /// This constructor is **async** because it establishes a WebSocket connection.
+    /// For basic sync operations, use `new()`. For custom configuration, use `HeliusBuilder`.
     ///
     /// # Arguments
     /// * `api_key` - The API key required for authenticating the requests made
     /// * `cluster` - The Solana cluster (Devnet or MainnetBeta) that defines the given network environment
-    /// * `commitment` - The commitment level to use for the Solana client
     ///
     /// # Returns
-    /// An instance of `Helius` if successful. A `HeliusError` is returned if an error occurs during configuration or initialization of the HTTP or RPC client
+    /// An instance of `Helius` if successful. A `HeliusError` is returned if an error occurs during configuration or initialization
     ///
     /// # Example
-    /// ```rust
-    /// use helius::client::Helius;
+    /// ```ignore
+    /// use helius::Helius;
     /// use helius::types::Cluster;
-    /// use solana_commitment_config::CommitmentConfig;
     ///
-    /// let helius = Helius::new_with_commitment("your_api_key", Cluster::Devnet, CommitmentConfig::confirmed()).expect("Failed to create a Helius client");
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let helius = Helius::new_async("your_api_key", Cluster::MainnetBeta)
+    ///         .await
+    ///         .expect("Failed to create a Helius client");
+    ///
+    ///     // Access async client
+    ///     let async_client = helius.async_connection().expect("Async client available");
+    ///
+    ///     // Access WebSocket
+    ///     let ws = helius.ws().expect("WebSocket available");
+    /// }
     /// ```
-    pub fn new_with_commitment(api_key: &str, cluster: Cluster, commitment: CommitmentConfig) -> Result<Self> {
-        let config: Arc<Config> = Arc::new(Config::new(api_key, cluster)?);
-        let client: Client = Client::builder().build().map_err(HeliusError::ReqwestError)?;
-        let rpc_client: Arc<RpcClient> = Arc::new(RpcClient::new_with_commitment(
-            Arc::new(client.clone()),
-            config.clone(),
-            commitment,
-        )?);
-
-        Ok(Helius {
-            config,
-            client,
-            rpc_client,
-            async_rpc_client: None,
-            ws_client: None,
-        })
+    pub async fn new_async(api_key: &str, cluster: Cluster) -> Result<Self> {
+        crate::HeliusBuilder::new()
+            .with_api_key(api_key)?
+            .with_cluster(cluster)
+            .with_async_solana()
+            .with_websocket(None, None)
+            .with_commitment(CommitmentConfig::confirmed())
+            .build()
+            .await
     }
 
-    /// Creates a new instance of `Helius` with an asynchronous Solana client
+    /// Creates a Helius client with a custom RPC URL
+    ///
+    /// Use this when you want to:
+    /// - Connect to your own RPC node
+    /// - Use a third-party RPC provider
+    /// - Point to localhost for development
+    /// - Route through a proxy
+    ///
+    /// This constructor is **synchronous** and does not require `.await`.
+    /// API key is optional when using custom URLs. You can add one via `HeliusBuilder`
+    /// if your custom endpoint requires authentication.
     ///
     /// # Arguments
-    /// * `api_key` - The API key required for authenticating the requests made
-    /// * `cluster` - The Solana cluster (Devnet or MainnetBeta) that defines the given network environment
+    /// * `url` - The custom RPC endpoint URL (http:// or https://)
     ///
     /// # Returns
-    /// An instance of `Helius` if successful. A `HeliusError` is returned if an error occurs during configuration or initialization of the HTTP or RPC client
+    /// An instance of `Helius` if successful. A `HeliusError` is returned if the URL is invalid
     ///
     /// # Example
     /// ```rust
     /// use helius::Helius;
-    /// use helius::types::Cluster;
     ///
-    /// let helius = Helius::new_with_async_solana("your_api_key", Cluster::Devnet).expect("Failed to create a Helius client");
+    /// // Production custom RPC
+    /// let helius = Helius::new_with_url("https://my-rpc-provider.com/")
+    ///     .expect("Failed to create client");
+    ///
+    /// // Local development
+    /// let local_helius = Helius::new_with_url("http://localhost:8899")
+    ///     .expect("Failed to create client");
     /// ```
-    pub fn new_with_async_solana(api_key: &str, cluster: Cluster) -> Result<Self> {
-        let config: Arc<Config> = Arc::new(Config::new(api_key, cluster)?);
-        let client: Client = Client::builder().build().map_err(HeliusError::ReqwestError)?;
-        let url: String = format!("{}/?api-key={}", config.endpoints.rpc, config.api_key);
-        let async_solana_client: Arc<AsyncSolanaRpcClient> = Arc::new(AsyncSolanaRpcClient::new(url));
+    pub fn new_with_url(url: &str) -> Result<Self> {
+        let validated = validate_rpc_url(url)?;
+        let url_string = validated.to_string();
+        let config = Arc::new(Config {
+            api_key: None,
+            cluster: Cluster::Devnet, // Default for custom URLs
+            endpoints: HeliusEndpoints {
+                api: url_string.clone(),
+                rpc: url_string.clone(),
+            },
+            custom_url: Some(url_string),
+        });
 
-        Ok(Helius {
-            config: config.clone(),
-            client: client.clone(),
-            rpc_client: Arc::new(RpcClient::new(Arc::new(client), config.clone())?),
-            async_rpc_client: Some(async_solana_client),
-            ws_client: None,
-        })
-    }
-
-    /// Creates a new instance of `Helius` with an asynchronous Solana client
-    /// and a commitment config
-    ///
-    /// # Arguments
-    /// * `api_key` - The API key required for authenticating the requests made
-    /// * `cluster` - The Solana cluster (Devnet or MainnetBeta) that defines the given network environment
-    /// * `commitment` - The commitment level to use for the asynchronous Solana client
-    ///
-    /// # Returns
-    /// An instance of `Helius` if successful. A `HeliusError` is returned if an error occurs during configuration or initialization of the HTTP or RPC client
-    ///
-    /// # Example
-    /// ```rust
-    /// use helius::Helius;
-    /// use helius::types::Cluster;
-    /// use solana_commitment_config::CommitmentConfig;
-    ///
-    /// let helius = Helius::new_with_async_solana_and_commitment("your_api_key", Cluster::Devnet, CommitmentConfig::confirmed()).expect("Failed to create a Helius client");
-    /// ```
-    ///
-    pub fn new_with_async_solana_and_commitment(
-        api_key: &str,
-        cluster: Cluster,
-        commitment: CommitmentConfig,
-    ) -> Result<Self> {
-        let config: Arc<Config> = Arc::new(Config::new(api_key, cluster)?);
-        let client: Client = Client::builder().build().map_err(HeliusError::ReqwestError)?;
-        let url: String = format!("{}/?api-key={}", config.endpoints.rpc, config.api_key);
-        let async_solana_client: Arc<AsyncSolanaRpcClient> =
-            Arc::new(AsyncSolanaRpcClient::new_with_commitment(url, commitment));
-
-        Ok(Helius {
-            config: config.clone(),
-            client: client.clone(),
-            rpc_client: Arc::new(RpcClient::new_with_commitment(
-                Arc::new(client),
-                config.clone(),
-                commitment,
-            )?),
-            async_rpc_client: Some(async_solana_client),
-            ws_client: None,
-        })
-    }
-
-    /// The enhanced websocket is optional, and this method is used to create a new instance of `Helius` with an enhanced websocket client.
-    /// Upon calling this method, the websocket will connect hence the asynchronous function definition omission from the default `new` method.
-    ///
-    /// # Arguments
-    /// * `api_key` - The API key required for authenticating requests made
-    /// * `cluster` - The Solana cluster (Devnet or MainnetBeta) that defines the given network environment
-    /// * `ping_interval_secs` - Optional duration in seconds between ping messages (defaults to 10 seconds if None)
-    /// * `pong_timeout_secs` - Optional duration in seconds to wait for a pong response before considering the connection dead
-    ///
-    /// # Returns
-    /// An instance of `Helius` if successful. A `HeliusError` is returned if an error occurs during configuration or initialization of the HTTP, RPC, or WS client
-    pub async fn new_with_ws_with_timeouts(
-        api_key: &str,
-        cluster: Cluster,
-        ping_interval_secs: Option<u64>,
-        pong_timeout_secs: Option<u64>,
-    ) -> Result<Self> {
-        let config: Arc<Config> = Arc::new(Config::new(api_key, cluster.clone())?);
-        let client: Client = Client::builder().build().map_err(HeliusError::ReqwestError)?;
-        let rpc_client: Arc<RpcClient> = Arc::new(RpcClient::new(Arc::new(client.clone()), config.clone())?);
-
-        let wss: String = EnhancedWebsocket::get_url(&cluster, api_key)?;
-        let ws_client: Arc<EnhancedWebsocket> =
-            Arc::new(EnhancedWebsocket::new(&wss, ping_interval_secs, pong_timeout_secs).await?);
+        let client = Client::builder().build().map_err(HeliusError::ReqwestError)?;
+        let rpc_client = Arc::new(RpcClient::new(Arc::new(client.clone()), config.clone())?);
 
         Ok(Helius {
             config,
             client,
             rpc_client,
             async_rpc_client: None,
-            ws_client: Some(ws_client),
+            ws_client: None,
         })
-    }
-
-    /// Creates a new instance of `Helius` with an enhanced websocket client using default timeout settings.
-    /// This is a convenience method that uses default values of 10 seconds for ping interval and 3 failed pings
-    /// before considering the connection dead.
-    ///
-    /// # Arguments
-    /// * `api_key` - The API key required for authenticating requests made
-    /// * `cluster` - The Solana cluster (Devnet or MainnetBeta) that defines the given network environment
-    ///
-    /// # Returns
-    /// An instance of `Helius` if successful. A `HeliusError` is returned if an error occurs during configuration or initialization of the HTTP, RPC, or WS client
-    pub async fn new_with_ws(api_key: &str, cluster: Cluster) -> Result<Self> {
-        Self::new_with_ws_with_timeouts(api_key, cluster, None, None).await
     }
 
     /// Provides a thread-safe way to access RPC functionalities

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,25 +1,28 @@
 use crate::error::{HeliusError, Result};
 use crate::rpc_client::RpcClient;
-use crate::types::{Cluster, HeliusEndpoints, MintApiAuthority};
+use crate::types::{ApiKey, Cluster, HeliusEndpoints, MintApiAuthority};
 use crate::websocket::EnhancedWebsocket;
 use crate::Helius;
 use reqwest::Client;
 use solana_client::nonblocking::rpc_client::RpcClient as AsyncSolanaRpcClient;
 use std::sync::Arc;
-use url::{ParseError, Url};
+use url::Url;
 
 /// Configuration settings for the Helius client
 ///
 /// `Config` contains all the necessary parameters needed to configure and authenticate the `Helius` client to interact with a specific Solana cluster
 #[derive(Clone)]
 pub struct Config {
-    /// The API key used for authenticating requests
-    pub api_key: String,
+    /// Optional API key for authentication.
+    /// Required for webhooks, enhanced transactions, and Helius-hosted endpoints.
+    pub api_key: Option<ApiKey>,
     /// The target Solana cluster the client will interact with
     pub cluster: Cluster,
     /// The endpoints associated with the specified `cluster`. Note these endpoints are automatically determined based on the cluster to ensure requests
     /// are made to the correct cluster
     pub endpoints: HeliusEndpoints,
+    /// Custom RPC URL if provided (for debugging/logging)
+    pub custom_url: Option<String>,
 }
 
 impl Config {
@@ -34,18 +37,73 @@ impl Config {
     ///
     /// # Errors
     /// Returns `HeliusError::InvalidInput` if the `api_key` is empty
+    ///
+    /// # Deprecated
+    /// Use `HeliusBuilder` for more flexible configuration:
+    /// ```ignore
+    /// use helius::HeliusBuilder;
+    /// use helius::types::Cluster;
+    ///
+    /// let helius = HeliusBuilder::new()
+    ///     .with_api_key("key")?
+    ///     .with_cluster(Cluster::MainnetBeta)
+    ///     .build()
+    ///     .await?;
+    /// ```
     pub fn new(api_key: &str, cluster: Cluster) -> Result<Self> {
-        if api_key.is_empty() {
-            return Err(HeliusError::InvalidInput("API key cannot be empty".to_string()));
-        }
-
         let endpoints: HeliusEndpoints = HeliusEndpoints::for_cluster(&cluster);
 
         Ok(Config {
-            api_key: api_key.to_string(),
+            api_key: Some(ApiKey::new(api_key)?),
             cluster,
             endpoints,
+            custom_url: None,
         })
+    }
+
+    /// Checks if an API key is available.
+    pub fn has_api_key(&self) -> bool {
+        self.api_key.is_some()
+    }
+
+    /// Gets the API key or returns an error with helpful guidance.
+    ///
+    /// Use this in methods that require authentication.
+    ///
+    /// # Errors
+    /// Returns `HeliusError::InvalidInput` if no API key is configured.
+    pub fn require_api_key(&self, feature: &str) -> Result<&ApiKey> {
+        self.api_key.as_ref().ok_or_else(|| {
+            HeliusError::InvalidInput(format!(
+                "API key is required for {}. \
+                 Initialize with HeliusBuilder::new().with_api_key(\"your-key\")",
+                feature
+            ))
+        })
+    }
+
+    /// Builds an RPC URL with authentication.
+    ///
+    /// Appends api-key query parameter only if key is present.
+    pub fn build_rpc_url(&self) -> String {
+        self.build_url(&self.endpoints.rpc)
+    }
+
+    /// Builds an API URL with authentication.
+    pub fn build_api_url(&self) -> String {
+        self.build_url(&self.endpoints.api)
+    }
+
+    /// Internal: Builds a URL with optional API key parameter.
+    fn build_url(&self, base: &str) -> String {
+        let mut url = Url::parse(base)
+            .expect("Config endpoints should always be valid URLs");
+
+        if let Some(ref key) = self.api_key {
+            url.query_pairs_mut().append_pair("api-key", key.as_str());
+        }
+
+        url.to_string()
     }
 
     pub fn rpc_client_with_reqwest_client(&self, client: Client) -> Result<RpcClient> {
@@ -75,12 +133,9 @@ impl Config {
     /// A `Result` containing a Helius client with both RPC and async Solana capabilities
     pub fn create_client_with_async(self) -> Result<Helius> {
         let client: Client = Client::builder().build().map_err(HeliusError::ReqwestError)?;
-        let mut rpc_url: Url = Url::parse(&self.endpoints.rpc)
-            .map_err(|e: ParseError| HeliusError::InvalidInput(format!("Invalid RPC URL: {}", e)))?;
+        let rpc_url = self.build_rpc_url();
 
-        rpc_url.query_pairs_mut().append_pair("api-key", &self.api_key);
-
-        let async_solana_client: Arc<AsyncSolanaRpcClient> = Arc::new(AsyncSolanaRpcClient::new(rpc_url.to_string()));
+        let async_solana_client: Arc<AsyncSolanaRpcClient> = Arc::new(AsyncSolanaRpcClient::new(rpc_url));
         let rpc_client: Arc<RpcClient> = Arc::new(self.rpc_client_with_reqwest_client(client.clone())?);
 
         Ok(Helius {
@@ -108,7 +163,8 @@ impl Config {
         let client: Client = Client::builder().build().map_err(HeliusError::ReqwestError)?;
         let rpc_client: Arc<RpcClient> = Arc::new(self.rpc_client_with_reqwest_client(client.clone())?);
 
-        let wss: String = EnhancedWebsocket::get_url(&self.cluster, &self.api_key)?;
+        let api_key = self.require_api_key("WebSocket connections")?;
+        let wss: String = EnhancedWebsocket::get_url(&self.cluster, api_key.as_str())?;
         let ws_client: Arc<EnhancedWebsocket> =
             Arc::new(EnhancedWebsocket::new(&wss, ping_interval_secs, pong_timeout_secs).await?);
 
@@ -138,13 +194,12 @@ impl Config {
         let rpc_client: Arc<RpcClient> = Arc::new(self.rpc_client_with_reqwest_client(client.clone())?);
 
         // Setup async client
-        let mut rpc_url: Url = Url::parse(&self.endpoints.rpc)
-            .map_err(|e: ParseError| HeliusError::InvalidInput(format!("Invalid RPC URL: {}", e)))?;
-        rpc_url.query_pairs_mut().append_pair("api-key", &self.api_key);
-        let async_solana_client = Arc::new(AsyncSolanaRpcClient::new(rpc_url.to_string()));
+        let rpc_url = self.build_rpc_url();
+        let async_solana_client = Arc::new(AsyncSolanaRpcClient::new(rpc_url));
 
         // Setup websocket
-        let wss: String = EnhancedWebsocket::get_url(&self.cluster, &self.api_key)?;
+        let api_key = self.require_api_key("WebSocket connections")?;
+        let wss: String = EnhancedWebsocket::get_url(&self.cluster, api_key.as_str())?;
         let ws_client: Arc<EnhancedWebsocket> =
             Arc::new(EnhancedWebsocket::new(&wss, ping_interval_secs, pong_timeout_secs).await?);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -96,8 +96,7 @@ impl Config {
 
     /// Internal: Builds a URL with optional API key parameter.
     fn build_url(&self, base: &str) -> String {
-        let mut url = Url::parse(base)
-            .expect("Config endpoints should always be valid URLs");
+        let mut url = Url::parse(base).expect("Config endpoints should always be valid URLs");
 
         if let Some(ref key) = self.api_key {
             url.query_pairs_mut().append_pair("api-key", key.as_str());

--- a/src/enhanced_transactions.rs
+++ b/src/enhanced_transactions.rs
@@ -14,9 +14,10 @@ impl Helius {
     /// # Returns
     /// A `Result` wrapping a vector of `EnhancedTransaction`s
     pub async fn parse_transactions(&self, request: ParseTransactionsRequest) -> Result<Vec<EnhancedTransaction>> {
+        let api_key = self.config.require_api_key("enhanced transaction parsing")?;
         let url: String = format!(
             "{}v0/transactions?api-key={}",
-            self.config.endpoints.api, self.config.api_key
+            self.config.endpoints.api, api_key.as_str()
         );
         let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
 
@@ -39,9 +40,10 @@ impl Helius {
         &self,
         request: ParsedTransactionHistoryRequest,
     ) -> Result<Vec<EnhancedTransaction>> {
+        let api_key = self.config.require_api_key("enhanced transaction history")?;
         let mut url: String = format!(
             "{}v0/addresses/{}/transactions?api-key={}",
-            self.config.endpoints.api, request.address, self.config.api_key
+            self.config.endpoints.api, request.address, api_key.as_str()
         );
 
         if let Some(before) = request.before {

--- a/src/enhanced_transactions.rs
+++ b/src/enhanced_transactions.rs
@@ -17,7 +17,8 @@ impl Helius {
         let api_key = self.config.require_api_key("enhanced transaction parsing")?;
         let url: String = format!(
             "{}v0/transactions?api-key={}",
-            self.config.endpoints.api, api_key.as_str()
+            self.config.endpoints.api,
+            api_key.as_str()
         );
         let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
 
@@ -43,7 +44,9 @@ impl Helius {
         let api_key = self.config.require_api_key("enhanced transaction history")?;
         let mut url: String = format!(
             "{}v0/addresses/{}/transactions?api-key={}",
-            self.config.endpoints.api, request.address, api_key.as_str()
+            self.config.endpoints.api,
+            request.address,
+            api_key.as_str()
         );
 
         if let Some(before) = request.before {

--- a/src/error.rs
+++ b/src/error.rs
@@ -26,7 +26,7 @@ pub enum HeliusError {
 
     /// Indicates if a client is not already initialized
     ///
-    /// Useful for the new_with_async_solana method on the `Helius` client
+    /// Returned when accessing `async_connection()` without enabling async via `HeliusBuilder` or `new_async()`
     #[error("Client not initialized: {text}")]
     ClientNotInitialized { text: String },
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod builder;
 pub mod client;
 pub mod config;
 pub mod enhanced_transactions;
@@ -13,6 +14,7 @@ pub mod utils;
 pub mod webhook;
 pub mod websocket;
 
+pub use builder::HeliusBuilder;
 pub use client::Helius;
 pub use factory::HeliusFactory;
 pub use request_handler::{SDK_USER_AGENT, SDK_VERSION};

--- a/src/rpc_client.rs
+++ b/src/rpc_client.rs
@@ -59,7 +59,7 @@ impl RpcClient {
     /// Returns `HeliusError` if the URL isn't formatted correctly or the `RequestHandler` fails to initialize
     pub fn new(client: Arc<Client>, config: Arc<Config>) -> Result<Self> {
         let handler: RequestHandler = RequestHandler::new(client)?;
-        let url: String = format!("{}/?api-key={}", config.endpoints.rpc, config.api_key);
+        let url: String = config.build_rpc_url();
         let solana_client: Arc<SolanaRpcClient> = Arc::new(SolanaRpcClient::new(url));
 
         Ok(RpcClient {
@@ -83,7 +83,7 @@ impl RpcClient {
     /// Returns `HeliusError` if the URL isn't formatted correctly or the `RequestHandler` fails to initialize
     pub fn new_with_commitment(client: Arc<Client>, config: Arc<Config>, commitment: CommitmentConfig) -> Result<Self> {
         let handler: RequestHandler = RequestHandler::new(client)?;
-        let url: String = format!("{}/?api-key={}", config.endpoints.rpc, config.api_key);
+        let url: String = config.build_rpc_url();
         let solana_client: Arc<SolanaRpcClient> = Arc::new(SolanaRpcClient::new_with_commitment(url, commitment));
 
         Ok(RpcClient {
@@ -109,7 +109,7 @@ impl RpcClient {
         R: Debug + Serialize + Send + Sync,
         T: Debug + DeserializeOwned + Default,
     {
-        let base_url: String = format!("{}/?api-key={}", self.config.endpoints.rpc, self.config.api_key);
+        let base_url: String = self.config.build_rpc_url();
         let url: Url = Url::parse(&base_url).expect("Failed to parse URL");
 
         let rpc_request: RpcRequest<R> = RpcRequest::new(method.to_string(), request);

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -12,3 +12,161 @@ pub use self::enhanced_websocket::{
 pub use self::enums::*;
 pub use self::inner::*;
 pub use self::options::*;
+
+use crate::error::{HeliusError, Result};
+use url::Url;
+
+/// Type-safe wrapper for Helius API keys.
+///
+/// Validates that keys are non-empty and provides type safety to prevent
+/// accidentally passing wrong strings as API keys.
+///
+/// # Examples
+///
+/// ```
+/// use helius::types::ApiKey;
+///
+/// let key = ApiKey::new("your-api-key").unwrap();
+/// assert_eq!(key.as_str(), "your-api-key");
+/// ```
+#[derive(Clone, Debug)]
+pub struct ApiKey(String);
+
+impl ApiKey {
+    /// Creates a new API key.
+    ///
+    /// # Errors
+    /// Returns `HeliusError::InvalidInput` if the key is empty or whitespace-only.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use helius::types::ApiKey;
+    ///
+    /// let key = ApiKey::new("my-api-key").unwrap();
+    /// assert_eq!(key.as_str(), "my-api-key");
+    ///
+    /// // Empty keys are rejected
+    /// assert!(ApiKey::new("").is_err());
+    /// assert!(ApiKey::new("   ").is_err());
+    /// ```
+    pub fn new(key: impl Into<String>) -> Result<Self> {
+        let key = key.into();
+        let trimmed = key.trim();
+
+        if trimmed.is_empty() {
+            return Err(HeliusError::InvalidInput(
+                "API key cannot be empty".to_string()
+            ));
+        }
+
+        Ok(ApiKey(key))
+    }
+
+    /// Returns the API key as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<ApiKey> for String {
+    fn from(key: ApiKey) -> String {
+        key.0
+    }
+}
+
+/// Validates RPC URLs with essential security checks.
+///
+/// # Security
+/// - Only allows http/https schemes (prevents file://, javascript:, etc.)
+/// - Rejects embedded credentials (user:pass@ format)
+/// - Validates URL structure
+///
+/// # Arguments
+/// * `url` - The RPC endpoint URL to validate
+///
+/// # Examples
+/// ```
+/// use helius::types::validate_rpc_url;
+///
+/// // Valid URLs
+/// assert!(validate_rpc_url("https://api.mainnet-beta.solana.com").is_ok());
+/// assert!(validate_rpc_url("http://localhost:8899").is_ok());
+///
+/// // Invalid URLs
+/// assert!(validate_rpc_url("file:///etc/passwd").is_err());
+/// assert!(validate_rpc_url("https://user:pass@api.com").is_err());
+/// ```
+pub fn validate_rpc_url(url: &str) -> Result<Url> {
+    let parsed = Url::parse(url)
+        .map_err(|e| HeliusError::InvalidInput(
+            format!("Invalid URL format: {}. Expected: https://example.com/", e)
+        ))?;
+
+    // Only allow http/https schemes
+    match parsed.scheme() {
+        "http" | "https" => {},
+        scheme => return Err(HeliusError::InvalidInput(
+            format!(
+                "Invalid URL scheme '{}'. Only 'http' and 'https' are allowed for RPC endpoints.",
+                scheme
+            )
+        )),
+    }
+
+    // Reject credentials in URL (security risk - logged by proxies)
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(HeliusError::InvalidInput(
+            "URL contains embedded credentials. Remove them and use .with_api_key() instead.".to_string()
+        ));
+    }
+
+    Ok(parsed)
+}
+
+/// Validates WebSocket URLs (wss:// or ws://).
+///
+/// # Security
+/// - Only allows ws/wss schemes
+/// - Rejects embedded credentials
+/// - Validates URL structure
+///
+/// # Arguments
+/// * `url` - The WebSocket endpoint URL to validate
+///
+/// # Examples
+/// ```
+/// use helius::types::validate_ws_url;
+///
+/// // Valid URLs
+/// assert!(validate_ws_url("wss://atlas-mainnet.helius-rpc.com").is_ok());
+/// assert!(validate_ws_url("ws://localhost:8900").is_ok());
+///
+/// // Invalid URLs
+/// assert!(validate_ws_url("http://example.com").is_err());
+/// assert!(validate_ws_url("wss://user:pass@example.com").is_err());
+/// ```
+pub fn validate_ws_url(url: &str) -> Result<Url> {
+    let parsed = Url::parse(url)
+        .map_err(|e| HeliusError::InvalidInput(
+            format!("Invalid WebSocket URL: {}", e)
+        ))?;
+
+    match parsed.scheme() {
+        "ws" | "wss" => {},
+        scheme => return Err(HeliusError::InvalidInput(
+            format!(
+                "Invalid WebSocket scheme '{}'. Only 'ws' and 'wss' are allowed.",
+                scheme
+            )
+        )),
+    }
+
+    if !parsed.username().is_empty() || parsed.password().is_some() {
+        return Err(HeliusError::InvalidInput(
+            "WebSocket URL contains embedded credentials.".to_string()
+        ));
+    }
+
+    Ok(parsed)
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -55,9 +55,7 @@ impl ApiKey {
         let trimmed = key.trim();
 
         if trimmed.is_empty() {
-            return Err(HeliusError::InvalidInput(
-                "API key cannot be empty".to_string()
-            ));
+            return Err(HeliusError::InvalidInput("API key cannot be empty".to_string()));
         }
 
         Ok(ApiKey(key))
@@ -99,25 +97,23 @@ impl From<ApiKey> for String {
 /// ```
 pub fn validate_rpc_url(url: &str) -> Result<Url> {
     let parsed = Url::parse(url)
-        .map_err(|e| HeliusError::InvalidInput(
-            format!("Invalid URL format: {}. Expected: https://example.com/", e)
-        ))?;
+        .map_err(|e| HeliusError::InvalidInput(format!("Invalid URL format: {}. Expected: https://example.com/", e)))?;
 
     // Only allow http/https schemes
     match parsed.scheme() {
-        "http" | "https" => {},
-        scheme => return Err(HeliusError::InvalidInput(
-            format!(
+        "http" | "https" => {}
+        scheme => {
+            return Err(HeliusError::InvalidInput(format!(
                 "Invalid URL scheme '{}'. Only 'http' and 'https' are allowed for RPC endpoints.",
                 scheme
-            )
-        )),
+            )))
+        }
     }
 
     // Reject credentials in URL (security risk - logged by proxies)
     if !parsed.username().is_empty() || parsed.password().is_some() {
         return Err(HeliusError::InvalidInput(
-            "URL contains embedded credentials. Remove them and use .with_api_key() instead.".to_string()
+            "URL contains embedded credentials. Remove them and use .with_api_key() instead.".to_string(),
         ));
     }
 
@@ -147,24 +143,21 @@ pub fn validate_rpc_url(url: &str) -> Result<Url> {
 /// assert!(validate_ws_url("wss://user:pass@example.com").is_err());
 /// ```
 pub fn validate_ws_url(url: &str) -> Result<Url> {
-    let parsed = Url::parse(url)
-        .map_err(|e| HeliusError::InvalidInput(
-            format!("Invalid WebSocket URL: {}", e)
-        ))?;
+    let parsed = Url::parse(url).map_err(|e| HeliusError::InvalidInput(format!("Invalid WebSocket URL: {}", e)))?;
 
     match parsed.scheme() {
-        "ws" | "wss" => {},
-        scheme => return Err(HeliusError::InvalidInput(
-            format!(
+        "ws" | "wss" => {}
+        scheme => {
+            return Err(HeliusError::InvalidInput(format!(
                 "Invalid WebSocket scheme '{}'. Only 'ws' and 'wss' are allowed.",
                 scheme
-            )
-        )),
+            )))
+        }
     }
 
     if !parsed.username().is_empty() || parsed.password().is_some() {
         return Err(HeliusError::InvalidInput(
-            "WebSocket URL contains embedded credentials.".to_string()
+            "WebSocket URL contains embedded credentials.".to_string(),
         ));
     }
 

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -13,9 +13,10 @@ impl Helius {
     /// # Returns
     /// A `Result` wrapping a `Webhook` if the webhook is successfully created, or a `HeliusError` if creation fails
     pub async fn create_webhook(&self, request: CreateWebhookRequest) -> Result<Webhook> {
+        let api_key = self.config.require_api_key("webhook operations")?;
         let url: String = format!(
             "{}v0/webhooks?api-key={}",
-            self.config.endpoints.api, self.config.api_key
+            self.config.endpoints.api, api_key.as_str()
         );
         let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
 
@@ -33,9 +34,10 @@ impl Helius {
     /// # Returns
     /// A `Result` wrapping the updated `Webhook`, or a `HeliusError` if the edit request fails
     pub async fn edit_webhook(&self, request: EditWebhookRequest) -> Result<Webhook> {
+        let api_key = self.config.require_api_key("webhook operations")?;
         let url: String = format!(
             "{}v0/webhooks/{}?api-key={}",
-            self.config.endpoints.api, request.webhook_id, self.config.api_key
+            self.config.endpoints.api, request.webhook_id, api_key.as_str()
         );
         let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
 
@@ -110,9 +112,10 @@ impl Helius {
     /// # Returns
     /// A `Result` wrapping the `Webhook` queried, if it exists
     pub async fn get_webhook_by_id(&self, webhook_id: &str) -> Result<Webhook> {
+        let api_key = self.config.require_api_key("webhook operations")?;
         let url: String = format!(
             "{}v0/webhooks/{}?api-key={}",
-            self.config.endpoints.api, webhook_id, self.config.api_key
+            self.config.endpoints.api, webhook_id, api_key.as_str()
         );
         let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
 
@@ -126,9 +129,10 @@ impl Helius {
     /// # Returns
     /// A `Result` containing a vector of `Webhook` representing all configured webhooks for a given account
     pub async fn get_all_webhooks(&self) -> Result<Vec<Webhook>> {
+        let api_key = self.config.require_api_key("webhook operations")?;
         let url: String = format!(
             "{}v0/webhooks?api-key={}",
-            self.config.endpoints.api, self.config.api_key
+            self.config.endpoints.api, api_key.as_str()
         );
         let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
 
@@ -143,9 +147,10 @@ impl Helius {
     /// # Returns
     /// A unit since there isn't any response
     pub async fn delete_webhook(&self, webhook_id: &str) -> Result<()> {
+        let api_key = self.config.require_api_key("webhook operations")?;
         let url: String = format!(
             "{}v0/webhooks/{}?api-key={}",
-            self.config.endpoints.api, webhook_id, self.config.api_key
+            self.config.endpoints.api, webhook_id, api_key.as_str()
         );
         let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
 

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -14,10 +14,7 @@ impl Helius {
     /// A `Result` wrapping a `Webhook` if the webhook is successfully created, or a `HeliusError` if creation fails
     pub async fn create_webhook(&self, request: CreateWebhookRequest) -> Result<Webhook> {
         let api_key = self.config.require_api_key("webhook operations")?;
-        let url: String = format!(
-            "{}v0/webhooks?api-key={}",
-            self.config.endpoints.api, api_key.as_str()
-        );
+        let url: String = format!("{}v0/webhooks?api-key={}", self.config.endpoints.api, api_key.as_str());
         let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
 
         self.rpc_client
@@ -37,7 +34,9 @@ impl Helius {
         let api_key = self.config.require_api_key("webhook operations")?;
         let url: String = format!(
             "{}v0/webhooks/{}?api-key={}",
-            self.config.endpoints.api, request.webhook_id, api_key.as_str()
+            self.config.endpoints.api,
+            request.webhook_id,
+            api_key.as_str()
         );
         let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
 
@@ -115,7 +114,9 @@ impl Helius {
         let api_key = self.config.require_api_key("webhook operations")?;
         let url: String = format!(
             "{}v0/webhooks/{}?api-key={}",
-            self.config.endpoints.api, webhook_id, api_key.as_str()
+            self.config.endpoints.api,
+            webhook_id,
+            api_key.as_str()
         );
         let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
 
@@ -130,10 +131,7 @@ impl Helius {
     /// A `Result` containing a vector of `Webhook` representing all configured webhooks for a given account
     pub async fn get_all_webhooks(&self) -> Result<Vec<Webhook>> {
         let api_key = self.config.require_api_key("webhook operations")?;
-        let url: String = format!(
-            "{}v0/webhooks?api-key={}",
-            self.config.endpoints.api, api_key.as_str()
-        );
+        let url: String = format!("{}v0/webhooks?api-key={}", self.config.endpoints.api, api_key.as_str());
         let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
 
         self.rpc_client.handler.send(Method::GET, parsed_url, None::<&()>).await
@@ -150,7 +148,9 @@ impl Helius {
         let api_key = self.config.require_api_key("webhook operations")?;
         let url: String = format!(
             "{}v0/webhooks/{}?api-key={}",
-            self.config.endpoints.api, webhook_id, api_key.as_str()
+            self.config.endpoints.api,
+            webhook_id,
+            api_key.as_str()
         );
         let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
 

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -184,7 +184,7 @@ impl EnhancedWebsocket {
     /// Stream transactions with numerous configurations and filters to choose from.
     ///
     /// # Example
-    /// ```rust
+    /// ```ignore
     /// use helius::Helius;
     /// use helius::error::Result;
     /// use helius::types::{Cluster, RpcTransactionsConfig, TransactionSubscribeFilter, TransactionSubscribeOptions};
@@ -193,7 +193,7 @@ impl EnhancedWebsocket {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///   let helius = Helius::new("your_api_key", Cluster::MainnetBeta).expect("Failed to create a Helius client");
+    ///   let helius = Helius::new_async("your_api_key", Cluster::MainnetBeta).await.expect("Failed to create a Helius client");
     ///   // you may monitor transactions for any pubkey, this is just an example.
     ///   let key = pubkey!("BtsmiEEvnSuUnKxqXj2PZRYpPJAc7C34mGz8gtJ1DAaH");
     ///   let config = RpcTransactionsConfig {
@@ -220,7 +220,7 @@ impl EnhancedWebsocket {
     /// Stream accounts with numerous configurations and filters to choose from.
     ///
     /// # Example
-    /// ```rust
+    /// ```ignore
     /// use helius::Helius;
     /// use helius::error::Result;
     /// use helius::types::{Cluster, RpcTransactionsConfig, TransactionSubscribeFilter, TransactionSubscribeOptions};
@@ -229,7 +229,7 @@ impl EnhancedWebsocket {
     ///
     /// #[tokio::main]
     /// async fn main() -> Result<()> {
-    ///   let helius = Helius::new("your_api_key", Cluster::MainnetBeta).expect("Failed to create a Helius client");
+    ///   let helius = Helius::new_async("your_api_key", Cluster::MainnetBeta).await.expect("Failed to create a Helius client");
     ///   // you may monitor updates for any account pubkey, this is just an example.
     ///   let key = pubkey!("BtsmiEEvnSuUnKxqXj2PZRYpPJAc7C34mGz8gtJ1DAaH");
     ///   if let Some(ws) = helius.ws() {

--- a/tests/rpc/test_get_asset.rs
+++ b/tests/rpc/test_get_asset.rs
@@ -160,12 +160,13 @@ async fn test_get_asset_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -217,12 +218,13 @@ async fn test_get_asset_failure() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();

--- a/tests/rpc/test_get_asset_batch.rs
+++ b/tests/rpc/test_get_asset_batch.rs
@@ -4,9 +4,9 @@ use helius::client::Helius;
 use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
-use helius::types::{ApiKey, 
-    ApiResponse, Asset, Attribute, Attributes, Authorities, Cluster, CollectionMetadata, Compression, Content, Creator,
-    File, GetAssetBatch, GetAssetOptions, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership,
+use helius::types::{
+    ApiKey, ApiResponse, Asset, Attribute, Attributes, Authorities, Cluster, CollectionMetadata, Compression, Content,
+    Creator, File, GetAssetBatch, GetAssetOptions, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership,
     OwnershipModel, Royalty, RoyaltyModel, Scope, Supply,
 };
 

--- a/tests/rpc/test_get_asset_batch.rs
+++ b/tests/rpc/test_get_asset_batch.rs
@@ -4,7 +4,7 @@ use helius::client::Helius;
 use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
-use helius::types::{
+use helius::types::{ApiKey, 
     ApiResponse, Asset, Attribute, Attributes, Authorities, Cluster, CollectionMetadata, Compression, Content, Creator,
     File, GetAssetBatch, GetAssetOptions, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership,
     OwnershipModel, Royalty, RoyaltyModel, Scope, Supply,
@@ -254,12 +254,13 @@ async fn test_get_asset_batch_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -303,12 +304,13 @@ async fn test_get_asset_batch_failure() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();

--- a/tests/rpc/test_get_asset_proof.rs
+++ b/tests/rpc/test_get_asset_proof.rs
@@ -49,12 +49,13 @@ async fn test_get_asset_proof_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -98,12 +99,13 @@ async fn test_get_asset_proof_failure() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();

--- a/tests/rpc/test_get_asset_proof_batch.rs
+++ b/tests/rpc/test_get_asset_proof_batch.rs
@@ -52,12 +52,13 @@ async fn test_get_asset_proof_batch_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -108,12 +109,13 @@ async fn test_get_asset_proof_failure() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();

--- a/tests/rpc/test_get_assets_by_authority.rs
+++ b/tests/rpc/test_get_assets_by_authority.rs
@@ -1,7 +1,7 @@
 use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
-use helius::types::{
+use helius::types::{ApiKey, 
     ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File,
     GetAssetsByAuthority, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty,
     RoyaltyModel, Scope, Supply,
@@ -218,12 +218,13 @@ async fn test_get_assets_by_authority_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -265,12 +266,13 @@ async fn test_get_assets_by_authority_failure() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();

--- a/tests/rpc/test_get_assets_by_authority.rs
+++ b/tests/rpc/test_get_assets_by_authority.rs
@@ -1,9 +1,9 @@
 use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
-use helius::types::{ApiKey, 
-    ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File,
-    GetAssetsByAuthority, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty,
+use helius::types::{
+    ApiKey, ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator,
+    File, GetAssetsByAuthority, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty,
     RoyaltyModel, Scope, Supply,
 };
 use helius::Helius;

--- a/tests/rpc/test_get_assets_by_creator.rs
+++ b/tests/rpc/test_get_assets_by_creator.rs
@@ -1,7 +1,7 @@
 use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
-use helius::types::{
+use helius::types::{ApiKey, 
     ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File,
     GetAssetsByCreator, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty,
     RoyaltyModel, Scope, Supply,
@@ -218,12 +218,13 @@ async fn test_get_assets_by_creator_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -265,12 +266,13 @@ async fn test_get_assets_by_creator_failure() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();

--- a/tests/rpc/test_get_assets_by_creator.rs
+++ b/tests/rpc/test_get_assets_by_creator.rs
@@ -1,9 +1,9 @@
 use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
-use helius::types::{ApiKey, 
-    ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File,
-    GetAssetsByCreator, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty,
+use helius::types::{
+    ApiKey, ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator,
+    File, GetAssetsByCreator, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty,
     RoyaltyModel, Scope, Supply,
 };
 use helius::Helius;

--- a/tests/rpc/test_get_assets_by_group.rs
+++ b/tests/rpc/test_get_assets_by_group.rs
@@ -133,12 +133,13 @@ async fn test_get_assets_by_group_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -193,12 +194,13 @@ async fn test_get_assets_by_group_failure() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();

--- a/tests/rpc/test_get_assets_by_owner.rs
+++ b/tests/rpc/test_get_assets_by_owner.rs
@@ -1,9 +1,9 @@
 use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
-use helius::types::{ApiKey, 
-    ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File,
-    GetAssetsByOwner, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty,
+use helius::types::{
+    ApiKey, ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator,
+    File, GetAssetsByOwner, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty,
     RoyaltyModel, Scope, Supply,
 };
 use helius::Helius;

--- a/tests/rpc/test_get_assets_by_owner.rs
+++ b/tests/rpc/test_get_assets_by_owner.rs
@@ -1,7 +1,7 @@
 use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
-use helius::types::{
+use helius::types::{ApiKey, 
     ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File,
     GetAssetsByOwner, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty,
     RoyaltyModel, Scope, Supply,
@@ -148,12 +148,13 @@ async fn test_get_assets_by_owner_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -199,12 +200,13 @@ async fn test_get_assets_by_owner_failure() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();

--- a/tests/rpc/test_get_nft_editions.rs
+++ b/tests/rpc/test_get_nft_editions.rs
@@ -40,12 +40,13 @@ async fn test_get_nft_editions_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -93,12 +94,13 @@ async fn test_get_nft_editions_failure() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();

--- a/tests/rpc/test_get_priority_fee_estimate.rs
+++ b/tests/rpc/test_get_priority_fee_estimate.rs
@@ -38,12 +38,13 @@ async fn test_get_nft_editions_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -94,12 +95,13 @@ async fn test_get_nft_editions_failure() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();

--- a/tests/rpc/test_get_signatures_for_asset.rs
+++ b/tests/rpc/test_get_signatures_for_asset.rs
@@ -38,12 +38,13 @@ async fn test_get_asset_signatures_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -88,12 +89,13 @@ async fn test_get_asset_signatures_failure() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();

--- a/tests/rpc/test_get_token_accounts.rs
+++ b/tests/rpc/test_get_token_accounts.rs
@@ -45,12 +45,13 @@ async fn test_get_token_accounts_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -98,12 +99,13 @@ async fn test_get_token_accounts_failure() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();

--- a/tests/rpc/test_get_transactions_for_address.rs
+++ b/tests/rpc/test_get_transactions_for_address.rs
@@ -44,12 +44,13 @@ async fn test_get_transactions_for_address_success() {
         .create();
 
     let config = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client = Client::new();

--- a/tests/rpc/test_search_assets.rs
+++ b/tests/rpc/test_search_assets.rs
@@ -1,9 +1,9 @@
 use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
-use helius::types::{ApiKey, 
-    ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File,
-    Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty, RoyaltyModel, Scope,
+use helius::types::{
+    ApiKey, ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator,
+    File, Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty, RoyaltyModel, Scope,
     SearchAssets, Supply,
 };
 use helius::Helius;

--- a/tests/rpc/test_search_assets.rs
+++ b/tests/rpc/test_search_assets.rs
@@ -1,7 +1,7 @@
 use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
-use helius::types::{
+use helius::types::{ApiKey, 
     ApiResponse, Asset, AssetList, Attribute, Attributes, Authorities, Cluster, Compression, Content, Creator, File,
     Group, HeliusEndpoints, Interface, Links, Metadata, Ownership, OwnershipModel, Royalty, RoyaltyModel, Scope,
     SearchAssets, Supply,
@@ -148,12 +148,13 @@ async fn test_search_assets_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -196,12 +197,13 @@ async fn test_search_assets_failure() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();

--- a/tests/test_builder.rs
+++ b/tests/test_builder.rs
@@ -107,11 +107,7 @@ async fn test_builder_basic_with_api_key_and_cluster() {
 
 #[tokio::test]
 async fn test_builder_fails_without_cluster_or_url() {
-    let result = HeliusBuilder::new()
-        .with_api_key("test-key")
-        .unwrap()
-        .build()
-        .await;
+    let result = HeliusBuilder::new().with_api_key("test-key").unwrap().build().await;
 
     assert!(result.is_err());
     if let Err(HeliusError::InvalidInput(msg)) = result {
@@ -162,22 +158,19 @@ async fn test_builder_custom_url_with_api_key() {
 
 #[test]
 fn test_builder_custom_url_rejects_invalid() {
-    let result = HeliusBuilder::new()
-        .with_custom_url("not-a-url");
+    let result = HeliusBuilder::new().with_custom_url("not-a-url");
     assert!(result.is_err());
 }
 
 #[test]
 fn test_builder_custom_url_rejects_ftp() {
-    let result = HeliusBuilder::new()
-        .with_custom_url("ftp://files.example.com");
+    let result = HeliusBuilder::new().with_custom_url("ftp://files.example.com");
     assert!(result.is_err());
 }
 
 #[test]
 fn test_builder_custom_url_rejects_credentials() {
-    let result = HeliusBuilder::new()
-        .with_custom_url("https://user:pass@rpc.example.com");
+    let result = HeliusBuilder::new().with_custom_url("https://user:pass@rpc.example.com");
     assert!(result.is_err());
 }
 
@@ -267,10 +260,7 @@ async fn test_builder_with_async_and_commitment() {
 
 #[tokio::test]
 async fn test_builder_with_custom_http_client() {
-    let custom_client = reqwest::Client::builder()
-        .user_agent("helius-test")
-        .build()
-        .unwrap();
+    let custom_client = reqwest::Client::builder().user_agent("helius-test").build().unwrap();
 
     let result = HeliusBuilder::new()
         .with_api_key("test-key")
@@ -303,15 +293,13 @@ async fn test_builder_websocket_requires_api_key() {
 
 #[test]
 fn test_builder_custom_ws_url_valid() {
-    let builder = HeliusBuilder::new()
-        .with_custom_ws_url("wss://ws.example.com/");
+    let builder = HeliusBuilder::new().with_custom_ws_url("wss://ws.example.com/");
     assert!(builder.is_ok());
 }
 
 #[test]
 fn test_builder_custom_ws_url_rejects_http() {
-    let result = HeliusBuilder::new()
-        .with_custom_ws_url("http://ws.example.com/");
+    let result = HeliusBuilder::new().with_custom_ws_url("http://ws.example.com/");
     assert!(result.is_err());
 }
 

--- a/tests/test_builder.rs
+++ b/tests/test_builder.rs
@@ -1,0 +1,471 @@
+use helius::error::HeliusError;
+use helius::types::{ApiKey, Cluster};
+use helius::{Helius, HeliusBuilder};
+use solana_commitment_config::CommitmentConfig;
+
+// ===== ApiKey Validation =====
+
+#[test]
+fn test_api_key_valid() {
+    let key = ApiKey::new("my-api-key").unwrap();
+    assert_eq!(key.as_str(), "my-api-key");
+}
+
+#[test]
+fn test_api_key_empty_rejected() {
+    assert!(ApiKey::new("").is_err());
+}
+
+#[test]
+fn test_api_key_whitespace_only_rejected() {
+    assert!(ApiKey::new("   ").is_err());
+}
+
+#[test]
+fn test_api_key_into_string() {
+    let key = ApiKey::new("test-key").unwrap();
+    let s: String = key.into();
+    assert_eq!(s, "test-key");
+}
+
+// ===== URL Validation =====
+
+#[test]
+fn test_validate_rpc_url_https() {
+    assert!(helius::types::validate_rpc_url("https://api.mainnet-beta.solana.com").is_ok());
+}
+
+#[test]
+fn test_validate_rpc_url_http_localhost() {
+    assert!(helius::types::validate_rpc_url("http://localhost:8899").is_ok());
+}
+
+#[test]
+fn test_validate_rpc_url_rejects_file_scheme() {
+    assert!(helius::types::validate_rpc_url("file:///etc/passwd").is_err());
+}
+
+#[test]
+fn test_validate_rpc_url_rejects_javascript_scheme() {
+    assert!(helius::types::validate_rpc_url("javascript:alert(1)").is_err());
+}
+
+#[test]
+fn test_validate_rpc_url_rejects_credentials() {
+    assert!(helius::types::validate_rpc_url("https://user:pass@api.example.com").is_err());
+}
+
+#[test]
+fn test_validate_rpc_url_rejects_username_only() {
+    assert!(helius::types::validate_rpc_url("https://user@api.example.com").is_err());
+}
+
+#[test]
+fn test_validate_rpc_url_rejects_invalid_url() {
+    assert!(helius::types::validate_rpc_url("not a url").is_err());
+}
+
+#[test]
+fn test_validate_ws_url_wss() {
+    assert!(helius::types::validate_ws_url("wss://atlas-mainnet.helius-rpc.com").is_ok());
+}
+
+#[test]
+fn test_validate_ws_url_ws_localhost() {
+    assert!(helius::types::validate_ws_url("ws://localhost:8900").is_ok());
+}
+
+#[test]
+fn test_validate_ws_url_rejects_http() {
+    assert!(helius::types::validate_ws_url("http://example.com").is_err());
+}
+
+#[test]
+fn test_validate_ws_url_rejects_credentials() {
+    assert!(helius::types::validate_ws_url("wss://user:pass@example.com").is_err());
+}
+
+// ===== Builder: Basic Construction =====
+
+#[tokio::test]
+async fn test_builder_basic_with_api_key_and_cluster() {
+    let result = HeliusBuilder::new()
+        .with_api_key("test-key")
+        .unwrap()
+        .with_cluster(Cluster::Devnet)
+        .build()
+        .await;
+
+    assert!(result.is_ok());
+    let helius = result.unwrap();
+    assert!(helius.config.api_key.is_some());
+    assert_eq!(helius.config.api_key.as_ref().unwrap().as_str(), "test-key");
+    assert!(helius.config.custom_url.is_none());
+    assert!(helius.async_rpc_client.is_none());
+    assert!(helius.ws_client.is_none());
+}
+
+#[tokio::test]
+async fn test_builder_fails_without_cluster_or_url() {
+    let result = HeliusBuilder::new()
+        .with_api_key("test-key")
+        .unwrap()
+        .build()
+        .await;
+
+    assert!(result.is_err());
+    if let Err(HeliusError::InvalidInput(msg)) = result {
+        assert!(msg.contains("cluster") || msg.contains("custom URL"));
+    } else {
+        panic!("Expected InvalidInput error");
+    }
+}
+
+#[test]
+fn test_builder_fails_with_empty_api_key() {
+    let result = HeliusBuilder::new().with_api_key("");
+    assert!(result.is_err());
+}
+
+// ===== Builder: Custom URL =====
+
+#[tokio::test]
+async fn test_builder_custom_url_no_api_key() {
+    let result = HeliusBuilder::new()
+        .with_custom_url("http://localhost:8899")
+        .unwrap()
+        .build()
+        .await;
+
+    assert!(result.is_ok());
+    let helius = result.unwrap();
+    assert!(helius.config.api_key.is_none());
+    assert!(helius.config.custom_url.is_some());
+    assert_eq!(helius.config.custom_url.as_ref().unwrap(), "http://localhost:8899/");
+}
+
+#[tokio::test]
+async fn test_builder_custom_url_with_api_key() {
+    let result = HeliusBuilder::new()
+        .with_custom_url("https://my-rpc.example.com/")
+        .unwrap()
+        .with_api_key("my-key")
+        .unwrap()
+        .build()
+        .await;
+
+    assert!(result.is_ok());
+    let helius = result.unwrap();
+    assert!(helius.config.api_key.is_some());
+    assert!(helius.config.custom_url.is_some());
+}
+
+#[test]
+fn test_builder_custom_url_rejects_invalid() {
+    let result = HeliusBuilder::new()
+        .with_custom_url("not-a-url");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_builder_custom_url_rejects_ftp() {
+    let result = HeliusBuilder::new()
+        .with_custom_url("ftp://files.example.com");
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_builder_custom_url_rejects_credentials() {
+    let result = HeliusBuilder::new()
+        .with_custom_url("https://user:pass@rpc.example.com");
+    assert!(result.is_err());
+}
+
+// ===== Builder: Custom API URL =====
+
+#[tokio::test]
+async fn test_builder_separate_api_and_rpc_urls() {
+    let result = HeliusBuilder::new()
+        .with_custom_url("https://rpc.example.com/")
+        .unwrap()
+        .with_custom_api_url("https://api.example.com/")
+        .unwrap()
+        .build()
+        .await;
+
+    assert!(result.is_ok());
+    let helius = result.unwrap();
+    assert_eq!(helius.config.endpoints.rpc, "https://rpc.example.com/");
+    assert_eq!(helius.config.endpoints.api, "https://api.example.com/");
+}
+
+#[tokio::test]
+async fn test_builder_custom_url_defaults_api_to_rpc() {
+    let result = HeliusBuilder::new()
+        .with_custom_url("https://my-rpc.example.com/")
+        .unwrap()
+        .build()
+        .await;
+
+    assert!(result.is_ok());
+    let helius = result.unwrap();
+    // When only custom_url is set, API URL defaults to the same as RPC
+    assert_eq!(helius.config.endpoints.rpc, "https://my-rpc.example.com/");
+    assert_eq!(helius.config.endpoints.api, "https://my-rpc.example.com/");
+}
+
+// ===== Builder: Async Solana Client =====
+
+#[tokio::test]
+async fn test_builder_with_async_solana() {
+    let result = HeliusBuilder::new()
+        .with_api_key("test-key")
+        .unwrap()
+        .with_cluster(Cluster::Devnet)
+        .with_async_solana()
+        .build()
+        .await;
+
+    assert!(result.is_ok());
+    let helius = result.unwrap();
+    assert!(helius.async_rpc_client.is_some());
+    assert!(helius.ws_client.is_none());
+}
+
+// ===== Builder: Commitment =====
+
+#[tokio::test]
+async fn test_builder_with_commitment() {
+    let result = HeliusBuilder::new()
+        .with_api_key("test-key")
+        .unwrap()
+        .with_cluster(Cluster::Devnet)
+        .with_commitment(CommitmentConfig::confirmed())
+        .build()
+        .await;
+
+    assert!(result.is_ok());
+}
+
+#[tokio::test]
+async fn test_builder_with_async_and_commitment() {
+    let result = HeliusBuilder::new()
+        .with_api_key("test-key")
+        .unwrap()
+        .with_cluster(Cluster::MainnetBeta)
+        .with_async_solana()
+        .with_commitment(CommitmentConfig::finalized())
+        .build()
+        .await;
+
+    assert!(result.is_ok());
+    let helius = result.unwrap();
+    assert!(helius.async_rpc_client.is_some());
+}
+
+// ===== Builder: Custom HTTP Client =====
+
+#[tokio::test]
+async fn test_builder_with_custom_http_client() {
+    let custom_client = reqwest::Client::builder()
+        .user_agent("helius-test")
+        .build()
+        .unwrap();
+
+    let result = HeliusBuilder::new()
+        .with_api_key("test-key")
+        .unwrap()
+        .with_cluster(Cluster::Devnet)
+        .with_http_client(custom_client)
+        .build()
+        .await;
+
+    assert!(result.is_ok());
+}
+
+// ===== Builder: WebSocket (without real connection) =====
+
+#[tokio::test]
+async fn test_builder_websocket_requires_api_key() {
+    // WebSocket on Helius endpoints requires an API key
+    let result = HeliusBuilder::new()
+        .with_custom_url("http://localhost:8899")
+        .unwrap()
+        .with_websocket(None, None)
+        .build()
+        .await;
+
+    // Should fail because WS needs an API key (no custom WS URL provided)
+    assert!(result.is_err());
+}
+
+// ===== Builder: Custom WebSocket URL =====
+
+#[test]
+fn test_builder_custom_ws_url_valid() {
+    let builder = HeliusBuilder::new()
+        .with_custom_ws_url("wss://ws.example.com/");
+    assert!(builder.is_ok());
+}
+
+#[test]
+fn test_builder_custom_ws_url_rejects_http() {
+    let result = HeliusBuilder::new()
+        .with_custom_ws_url("http://ws.example.com/");
+    assert!(result.is_err());
+}
+
+// ===== Builder: Cluster Endpoints =====
+
+#[tokio::test]
+async fn test_builder_devnet_endpoints() {
+    let helius = HeliusBuilder::new()
+        .with_api_key("test-key")
+        .unwrap()
+        .with_cluster(Cluster::Devnet)
+        .build()
+        .await
+        .unwrap();
+
+    assert_eq!(helius.config.endpoints.rpc, "https://devnet.helius-rpc.com/");
+    assert_eq!(helius.config.endpoints.api, "https://api-devnet.helius-rpc.com/");
+}
+
+#[tokio::test]
+async fn test_builder_mainnet_endpoints() {
+    let helius = HeliusBuilder::new()
+        .with_api_key("test-key")
+        .unwrap()
+        .with_cluster(Cluster::MainnetBeta)
+        .build()
+        .await
+        .unwrap();
+
+    assert_eq!(helius.config.endpoints.rpc, "https://mainnet.helius-rpc.com/");
+    assert_eq!(helius.config.endpoints.api, "https://api-mainnet.helius-rpc.com/");
+}
+
+#[tokio::test]
+async fn test_builder_staked_mainnet_endpoints() {
+    let helius = HeliusBuilder::new()
+        .with_api_key("test-key")
+        .unwrap()
+        .with_cluster(Cluster::StakedMainnetBeta)
+        .build()
+        .await
+        .unwrap();
+
+    assert_eq!(helius.config.endpoints.rpc, "https://staked.helius-rpc.com/");
+    assert_eq!(helius.config.endpoints.api, "https://api-mainnet.helius-rpc.com/");
+}
+
+// ===== Config: URL Building =====
+
+#[test]
+fn test_config_build_rpc_url_with_api_key() {
+    let config = helius::config::Config::new("my-key", Cluster::Devnet).unwrap();
+    let url = config.build_rpc_url();
+    assert!(url.contains("api-key=my-key"));
+    assert!(url.starts_with("https://devnet.helius-rpc.com/"));
+}
+
+#[test]
+fn test_config_build_api_url_with_api_key() {
+    let config = helius::config::Config::new("my-key", Cluster::Devnet).unwrap();
+    let url = config.build_api_url();
+    assert!(url.contains("api-key=my-key"));
+    assert!(url.starts_with("https://api-devnet.helius-rpc.com/"));
+}
+
+#[test]
+fn test_config_require_api_key_when_present() {
+    let config = helius::config::Config::new("my-key", Cluster::Devnet).unwrap();
+    let key = config.require_api_key("test feature");
+    assert!(key.is_ok());
+    assert_eq!(key.unwrap().as_str(), "my-key");
+}
+
+#[test]
+fn test_config_require_api_key_when_absent() {
+    use helius::config::Config;
+    use helius::types::HeliusEndpoints;
+
+    let config = Config {
+        api_key: None,
+        cluster: Cluster::Devnet,
+        endpoints: HeliusEndpoints {
+            api: "https://api-devnet.helius-rpc.com/".to_string(),
+            rpc: "https://devnet.helius-rpc.com/".to_string(),
+        },
+        custom_url: None,
+    };
+
+    let result = config.require_api_key("webhooks");
+    assert!(result.is_err());
+    if let Err(HeliusError::InvalidInput(msg)) = result {
+        assert!(msg.contains("webhooks"));
+    } else {
+        panic!("Expected InvalidInput error");
+    }
+}
+
+#[test]
+fn test_config_has_api_key() {
+    let config = helius::config::Config::new("my-key", Cluster::Devnet).unwrap();
+    assert!(config.has_api_key());
+}
+
+// ===== Simplified Constructors =====
+
+#[tokio::test]
+async fn test_helius_new_creates_basic_client() {
+    let helius = Helius::new("test-key", Cluster::Devnet).unwrap();
+
+    assert!(helius.config.api_key.is_some());
+    assert_eq!(helius.config.api_key.as_ref().unwrap().as_str(), "test-key");
+    assert!(helius.async_rpc_client.is_none());
+    assert!(helius.ws_client.is_none());
+}
+
+#[tokio::test]
+async fn test_helius_new_rejects_empty_key() {
+    let result = Helius::new("", Cluster::Devnet);
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_helius_new_async_fails_without_real_connection() {
+    // new_async() includes WebSocket which requires a real Helius server
+    let result = Helius::new_async("fake-key", Cluster::Devnet).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_helius_new_with_url_localhost() {
+    let helius = Helius::new_with_url("http://localhost:8899").unwrap();
+
+    assert!(helius.config.api_key.is_none());
+    assert!(helius.config.custom_url.is_some());
+    assert!(helius.async_rpc_client.is_none());
+    assert!(helius.ws_client.is_none());
+}
+
+#[tokio::test]
+async fn test_helius_new_with_url_https() {
+    let helius = Helius::new_with_url("https://my-rpc.example.com/").unwrap();
+
+    assert!(helius.config.api_key.is_none());
+    assert!(helius.config.custom_url.is_some());
+}
+
+#[tokio::test]
+async fn test_helius_new_with_url_rejects_invalid() {
+    let result = Helius::new_with_url("not-a-url");
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_helius_new_with_url_rejects_credentials() {
+    let result = Helius::new_with_url("https://user:pass@rpc.example.com");
+    assert!(result.is_err());
+}

--- a/tests/test_client.rs
+++ b/tests/test_client.rs
@@ -1,10 +1,9 @@
 use helius::client::Helius;
 use helius::error::Result;
 use helius::types::Cluster;
-use solana_commitment_config::CommitmentConfig;
 
-#[test]
-fn test_creating_new_client_success() {
+#[tokio::test]
+async fn test_creating_new_client_success() {
     let api_key: &str = "valid-api-key";
     let cluster: Cluster = Cluster::Devnet;
 
@@ -12,38 +11,50 @@ fn test_creating_new_client_success() {
     assert!(result.is_ok());
 
     let helius: Helius = result.unwrap();
-    assert_eq!(helius.config.api_key, api_key);
+    assert!(helius.config.api_key.is_some());
+    assert_eq!(helius.config.api_key.as_ref().unwrap().as_str(), api_key);
 }
 
-#[test]
-fn test_creating_new_async_client_success() {
+#[tokio::test]
+async fn test_creating_new_async_client_fails_without_real_ws() {
+    // new_async() includes WebSocket, which requires a real connection.
+    // With a fake API key, the WS connection will fail.
     let api_key: &str = "valid-api-key";
     let cluster: Cluster = Cluster::Devnet;
 
-    let result: Result<Helius> = Helius::new_with_async_solana(api_key, cluster);
+    let result: Result<Helius> = Helius::new_async(api_key, cluster).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_creating_async_client_via_builder() {
+    // Use the builder directly without WebSocket for testability
+    use helius::HeliusBuilder;
+
+    let api_key: &str = "valid-api-key";
+    let cluster: Cluster = Cluster::Devnet;
+
+    let result: Result<Helius> = HeliusBuilder::new()
+        .with_api_key(api_key)
+        .unwrap()
+        .with_cluster(cluster)
+        .with_async_solana()
+        .build()
+        .await;
     assert!(result.is_ok());
 
     let helius: Helius = result.unwrap();
-    assert_eq!(helius.config.api_key, api_key);
+    assert!(helius.config.api_key.is_some());
+    assert_eq!(helius.config.api_key.as_ref().unwrap().as_str(), api_key);
     assert!(helius.async_rpc_client.is_some());
 }
 
-#[test]
-fn test_creating_new_client_with_commitment_success() {
-    let api_key: &str = "valid-api-key";
-    let cluster: Cluster = Cluster::Devnet;
-    let commitment: CommitmentConfig = CommitmentConfig::confirmed();
-
-    let result: Result<Helius> = Helius::new_with_commitment(api_key, cluster, commitment);
+#[tokio::test]
+async fn test_creating_new_client_with_custom_url_success() {
+    let result: Result<Helius> = Helius::new_with_url("http://localhost:8899");
     assert!(result.is_ok());
-}
 
-#[test]
-fn test_creating_new_async_client_with_commitment_success() {
-    let api_key: &str = "valid-api-key";
-    let cluster: Cluster = Cluster::Devnet;
-    let commitment: CommitmentConfig = CommitmentConfig::confirmed();
-
-    let result: Result<Helius> = Helius::new_with_async_solana_and_commitment(api_key, cluster, commitment);
-    assert!(result.is_ok());
+    let helius: Helius = result.unwrap();
+    assert!(helius.config.api_key.is_none());
+    assert!(helius.config.custom_url.is_some());
 }

--- a/tests/test_client_staked.rs
+++ b/tests/test_client_staked.rs
@@ -2,8 +2,8 @@ use helius::client::Helius;
 use helius::error::Result;
 use helius::types::Cluster;
 
-#[test]
-fn test_creating_new_client_staked_success() {
+#[tokio::test]
+async fn test_creating_new_client_staked_success() {
     let api_key: &str = "valid-api-key";
     let cluster: Cluster = Cluster::StakedMainnetBeta;
 
@@ -11,18 +11,17 @@ fn test_creating_new_client_staked_success() {
     assert!(result.is_ok());
 
     let helius: Helius = result.unwrap();
-    assert_eq!(helius.config.api_key, api_key);
+    assert!(helius.config.api_key.is_some());
+    assert_eq!(helius.config.api_key.as_ref().unwrap().as_str(), api_key);
 }
 
-#[test]
-fn test_creating_new_async_client_staked_success() {
+#[tokio::test]
+async fn test_creating_new_async_client_staked_fails_without_real_ws() {
+    // new_async() includes WebSocket, which requires a real connection.
+    // With a fake API key, the WS connection will fail.
     let api_key: &str = "valid-api-key";
     let cluster: Cluster = Cluster::StakedMainnetBeta;
 
-    let result: Result<Helius> = Helius::new_with_async_solana(api_key, cluster);
-    assert!(result.is_ok());
-
-    let helius: Helius = result.unwrap();
-    assert_eq!(helius.config.api_key, api_key);
-    assert!(helius.async_rpc_client.is_some());
+    let result: Result<Helius> = Helius::new_async(api_key, cluster).await;
+    assert!(result.is_err());
 }

--- a/tests/test_config.rs
+++ b/tests/test_config.rs
@@ -15,7 +15,8 @@ fn test_config_new_with_valid_api_key() {
     assert!(result.is_ok());
 
     let config: Config = result.unwrap();
-    assert_eq!(config.api_key, "valid-api-key");
+    assert!(config.api_key.is_some());
+    assert_eq!(config.api_key.as_ref().unwrap().as_str(), "valid-api-key");
     assert_eq!(config.endpoints.api, "https://api-devnet.helius-rpc.com/");
     assert_eq!(config.endpoints.rpc, "https://devnet.helius-rpc.com/");
 }

--- a/tests/test_enhanced_transactions.rs
+++ b/tests/test_enhanced_transactions.rs
@@ -2,7 +2,7 @@ use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
 use helius::types::{
-    AccountData, Cluster, EnhancedTransaction, HeliusEndpoints, InnerInstruction, Instruction,
+    AccountData, ApiKey, Cluster, EnhancedTransaction, HeliusEndpoints, InnerInstruction, Instruction,
     ParseTransactionsRequest, ParsedTransactionHistoryRequest, Source, TokenStandard, TokenTransfer, TransactionEvent,
     TransactionType, TransferUserAccounts,
 };
@@ -66,12 +66,13 @@ async fn test_parse_transactions_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -108,12 +109,13 @@ async fn test_parse_transactions_failure() {
     let url: String = format!("{}/", server.url());
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
     let client: Client = Client::new();
     let rpc_client: Arc<RpcClient> = Arc::new(RpcClient::new(Arc::new(client.clone()), Arc::clone(&config)).unwrap());
@@ -197,12 +199,13 @@ async fn test_parse_transaction_history_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -242,12 +245,13 @@ async fn test_parse_transaction_history_failure() {
     let url: String = format!("{}/", server.url());
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();

--- a/tests/test_factory.rs
+++ b/tests/test_factory.rs
@@ -6,7 +6,8 @@ fn test_factory_create_devnet_instance() {
     let factory: HeliusFactory = HeliusFactory::new("valid_api_key");
     let helius: Helius = factory.create(Cluster::Devnet).unwrap();
 
-    assert_eq!(helius.config.api_key, "valid_api_key");
+    assert!(helius.config.api_key.is_some());
+    assert_eq!(helius.config.api_key.as_ref().unwrap().as_str(), "valid_api_key");
     assert_eq!(helius.config.endpoints.api, "https://api-devnet.helius-rpc.com/");
     assert_eq!(helius.config.endpoints.rpc, "https://devnet.helius-rpc.com/");
 }
@@ -16,7 +17,8 @@ fn test_factory_create_mainnet_instance() {
     let factory: HeliusFactory = HeliusFactory::new("valid_api_key");
     let helius: Helius = factory.create(Cluster::MainnetBeta).unwrap();
 
-    assert_eq!(helius.config.api_key, "valid_api_key");
+    assert!(helius.config.api_key.is_some());
+    assert_eq!(helius.config.api_key.as_ref().unwrap().as_str(), "valid_api_key");
     assert_eq!(helius.config.endpoints.api, "https://api-mainnet.helius-rpc.com/");
     assert_eq!(helius.config.endpoints.rpc, "https://mainnet.helius-rpc.com/");
 }
@@ -26,7 +28,8 @@ fn test_factory_create_staked_mainnet_instance() {
     let factory: HeliusFactory = HeliusFactory::new("valid_api_key");
     let helius: Helius = factory.create(Cluster::StakedMainnetBeta).unwrap();
 
-    assert_eq!(helius.config.api_key, "valid_api_key");
+    assert!(helius.config.api_key.is_some());
+    assert_eq!(helius.config.api_key.as_ref().unwrap().as_str(), "valid_api_key");
     assert_eq!(helius.config.endpoints.api, "https://api-mainnet.helius-rpc.com/");
     assert_eq!(helius.config.endpoints.rpc, "https://staked.helius-rpc.com/");
 }
@@ -39,7 +42,8 @@ fn test_factory_create_with_reqwest() {
         .create(Cluster::MainnetBeta)
         .unwrap();
 
-    assert_eq!(helius.config.api_key, "valid_api_key");
+    assert!(helius.config.api_key.is_some());
+    assert_eq!(helius.config.api_key.as_ref().unwrap().as_str(), "valid_api_key");
     assert_eq!(helius.config.endpoints.api, "https://api-mainnet.helius-rpc.com/");
     assert_eq!(helius.config.endpoints.rpc, "https://mainnet.helius-rpc.com/");
 }

--- a/tests/webhook/test_append_addresses_to_webhook.rs
+++ b/tests/webhook/test_append_addresses_to_webhook.rs
@@ -1,7 +1,7 @@
 use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
-use helius::types::{Cluster, HeliusEndpoints, TransactionType, Webhook, WebhookType};
+use helius::types::{ApiKey, Cluster, HeliusEndpoints, TransactionType, Webhook, WebhookType};
 use helius::Helius;
 use mockito::Server;
 use reqwest::Client;
@@ -49,12 +49,13 @@ async fn test_append_addresses_to_webhook_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -118,12 +119,13 @@ async fn test_append_addresses_to_webhook_failure() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();

--- a/tests/webhook/test_create_webhook.rs
+++ b/tests/webhook/test_create_webhook.rs
@@ -1,7 +1,7 @@
 use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
-use helius::types::{Cluster, CreateWebhookRequest, HeliusEndpoints, TransactionType, Webhook, WebhookType};
+use helius::types::{ApiKey, Cluster, CreateWebhookRequest, HeliusEndpoints, TransactionType, Webhook, WebhookType};
 use helius::Helius;
 use mockito::Server;
 use reqwest::Client;
@@ -32,12 +32,13 @@ async fn test_create_webhook_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -82,12 +83,13 @@ async fn test_create_webhook_failure() {
         .with_body(r#"{"error":"Internal Server Error"}"#)
         .create();
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
     let request: CreateWebhookRequest = CreateWebhookRequest {
         webhook_url: "https://webhook.site/0e8250a1-ceec-4757-ad69-cc6473085bfc".to_string(),

--- a/tests/webhook/test_delete_webhook.rs
+++ b/tests/webhook/test_delete_webhook.rs
@@ -1,7 +1,7 @@
 use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
-use helius::types::{Cluster, HeliusEndpoints};
+use helius::types::{ApiKey, Cluster, HeliusEndpoints};
 use helius::Helius;
 use mockito::Server;
 use reqwest::Client;
@@ -19,12 +19,13 @@ async fn test_delete_webhook_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -54,12 +55,13 @@ async fn test_delete_webhook_failure() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();

--- a/tests/webhook/test_edit_webhook.rs
+++ b/tests/webhook/test_edit_webhook.rs
@@ -1,7 +1,7 @@
 use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
-use helius::types::{Cluster, EditWebhookRequest, HeliusEndpoints, TransactionType, Webhook, WebhookType};
+use helius::types::{ApiKey, Cluster, EditWebhookRequest, HeliusEndpoints, TransactionType, Webhook, WebhookType};
 use helius::Helius;
 use mockito::Server;
 use reqwest::Client;
@@ -32,12 +32,13 @@ async fn test_edit_webhook_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -89,12 +90,13 @@ async fn test_edit_webhook_failure() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
     let client: Client = Client::new();
     let rpc_client: Arc<RpcClient> = Arc::new(RpcClient::new(Arc::new(client.clone()), Arc::clone(&config)).unwrap());

--- a/tests/webhook/test_get_all_webhooks.rs
+++ b/tests/webhook/test_get_all_webhooks.rs
@@ -1,7 +1,7 @@
 use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
-use helius::types::{Cluster, HeliusEndpoints, TransactionType, Webhook, WebhookType};
+use helius::types::{ApiKey, Cluster, HeliusEndpoints, TransactionType, Webhook, WebhookType};
 use helius::Helius;
 use mockito::Server;
 use reqwest::Client;
@@ -30,12 +30,13 @@ async fn test_get_all_webhooks_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -74,12 +75,13 @@ async fn test_get_all_webhooks_failure() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();

--- a/tests/webhook/test_get_webhook_by_id.rs
+++ b/tests/webhook/test_get_webhook_by_id.rs
@@ -1,7 +1,7 @@
 use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
-use helius::types::{Cluster, HeliusEndpoints, TransactionType, Webhook, WebhookType};
+use helius::types::{ApiKey, Cluster, HeliusEndpoints, TransactionType, Webhook, WebhookType};
 use helius::Helius;
 use mockito::Server;
 use reqwest::Client;
@@ -31,12 +31,13 @@ async fn test_get_webhook_by_id_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -74,12 +75,13 @@ async fn test_get_webhook_by_id_failure() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();

--- a/tests/webhook/test_remove_addresses_from_webhook.rs
+++ b/tests/webhook/test_remove_addresses_from_webhook.rs
@@ -1,7 +1,7 @@
 use helius::config::Config;
 use helius::error::Result;
 use helius::rpc_client::RpcClient;
-use helius::types::{Cluster, HeliusEndpoints, TransactionType, Webhook, WebhookType};
+use helius::types::{ApiKey, Cluster, HeliusEndpoints, TransactionType, Webhook, WebhookType};
 use helius::Helius;
 use mockito::Server;
 use reqwest::Client;
@@ -53,12 +53,13 @@ async fn test_remove_addresses_from_webhook_success() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();
@@ -129,12 +130,13 @@ async fn test_remove_addresses_from_webhook_failure() {
         .create();
 
     let config: Arc<Config> = Arc::new(Config {
-        api_key: "fake_api_key".to_string(),
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
         cluster: Cluster::Devnet,
         endpoints: HeliusEndpoints {
             api: url.to_string(),
             rpc: url.to_string(),
         },
+        custom_url: None,
     });
 
     let client: Client = Client::new();


### PR DESCRIPTION
This PR aims to add custom URL support and simplify client creation by moving over to a new builder pattern

**TLDR**
- We add custom RPC URL support
- We simplify client creation by converting the six old constructors into three new ones (i.e., `new()`, `new_async()`, and `new_with_url()`
- We add `HeliusBuilder` for advanced configs
- We make API keys optional, required only for webhooks and Enhanced Transactions

**Breaking Changes**
- `Helius::new()` will continue to work and is still sync, so no changes for most users
- We remove `new_with_commitment`, `new_with_async_solana`, `new_with_ws`, etc.
- `Config.api_key` is now `Option<ApiKey` instead of `String`

**Migration**
- Most code works unchanged, with the exception of things like `Helius::new_with_ws` which would now be `Helius::new_async`
- We have MIGRATION.md as a migration guide for users, and it has its own section on the README