### PR TITLE
feat(github): Add Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug Report
+description: Report a bug in the Helius Rust SDK
+title: "[Bug]: "
+labels: ["bug", "triage"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping us squash bugs! Please fill out this form as completely as possible.
+
+  - type: input
+    id: sdk-version
+    attributes:
+      label: SDK Version
+      description: What version of the Helius SDK are you using? (Run `cargo tree -p helius` or check your Cargo.toml)
+      placeholder: e.g., 1.0.0
+    validations:
+      required: true
+
+  - type: input
+    id: environment
+    attributes:
+      label: Environment
+      description: Rust version, OS, Solana cluster (e.g., mainnet-beta), and relevant dependencies (e.g., solana-sdk version)
+      placeholder: e.g., Rust 1.85, Ubuntu 24.04, mainnet-beta, solana-sdk 3.0.0
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the Bug
+      description: A clear and concise description of what the bug is.
+      placeholder: When I call Helius::new(), it returns the following error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to Reproduce
+      description: Provide a minimal code example or steps to replicate the issue.
+      placeholder: |
+        1. Add dependency: cargo add helius
+        2. Code:
+           let helius = Helius::new("api_key", Cluster::MainnetBeta)?;
+           let asset = helius.rpc().get_asset(...).await?;
+        3. Run: cargo run
+        4. See error: ...
+      render: rust
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen instead?
+      placeholder: It should return a valid Helius instance without any errors.
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs/Screenshots
+      description: Include error messages, stack traces, or screenshots if applicable.
+      render: shell
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Additional Checks
+      options:
+        - label: I have searched for existing issues and this is not a duplicate.
+          required: true
+        - label: I have tested with the latest version.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,16 @@
+# No blank issues; users must pick a template
+blank_issues_enabled: false
+
+contact_links:
+  - name: General Support
+    url: https://discord.com/invite/6GXdee3gBj
+    about: Ask questions or get help in our Discord
+  - name: Documentation
+    url: https://www.helius.dev/docs
+    about: Check out our docs for common questions and detailed guides
+  - name: Security vulnerability disclosure
+    url: mailto:support@helius.xyz
+    about: Please email us privately to report security issues
+  - name: Status Page
+    url: https://helius.statuspage.io/
+    about: Real-time information about service availability and performance

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,55 @@
+name: Feature Request
+description: Suggest an idea for the Helius Rust SDK
+title: "[Feature]: "
+labels: ["enhancement"]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for helping us improve the SDK! Please help us understand your idea.
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Feature Description
+      description: A clear and concise description of the new feature.
+      placeholder: Add support for executing swaps on platform X.
+    validations:
+      required: true
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use Case
+      description: Why do you need this? How would it benefit users or the SDK?
+      placeholder: This would allow users to integrate swaps on X with Sender more easily.
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: Any thoughts on how this could be implemented? (Optional)
+      placeholder: Add a new method that creates the swap instruction(s), and sends them via Sender.
+      render: rust
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Are you currently using a workaround or any other solutions? (Optional)
+      placeholder: Currently making and sending the swaps myself with basic RPC calls.
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Additional Checks
+      options:
+        - label: I have searched for existing issues and this is not a duplicate.
+          required: true


### PR DESCRIPTION
This PR aims to add issue templates, adding structure to bug reports and feature requests, while disabling blank issues and adding relevant contact info to the repo