### PR TITLE
fix(types): Add Camel Case Renaming to `UiTransactionEncoding`

### DIFF
--- a/src/types/enums.rs
+++ b/src/types/enums.rs
@@ -189,6 +189,7 @@ pub enum PriorityLevel {
 
 /// The encoding format for transaction data in RPC responses.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub enum UiTransactionEncoding {
     Binary,
     Base64,


### PR DESCRIPTION
This PR adds `#[serde(rename_all = "camelCase")]` to the `UiTransactionEncoding` enum to fix the issue where variants were serialized in Pascal case instead of Camel case