### PR TITLE
fix(logging): replace println!/eprintln! with log crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ base64 = "0.22.1"
 bincode = "1.3.3" # TODO: Update when solana updates.
 chrono = { version = "0.4.11", features = ["serde"] }
 futures-util = "0.3.30"
+log = "0.4"
 once_cell = "1.21.3"
 phf = { version = "0.13.1", features = ["macros"] }
 rand = "0.9.2"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -379,8 +379,8 @@ impl HeliusBuilder {
 
         // Warn if no API key for Helius endpoints
         if self.api_key.is_none() {
-            eprintln!(
-                "⚠️  Warning: No API key provided for Helius endpoint. \
+            log::warn!(
+                "No API key provided for Helius endpoint. \
                  Most features require authentication. Use .with_api_key(\"your-key\")"
             );
         }

--- a/src/request_handler.rs
+++ b/src/request_handler.rs
@@ -104,8 +104,8 @@ impl RequestHandler {
             match serde_json::from_str::<T>(&body_text) {
                 Ok(data) => Ok(data),
                 Err(e) => {
-                    println!("Deserialization error: {}", e);
-                    println!("Raw JSON: {}", body_text);
+                    log::error!("Deserialization error: {}", e);
+                    log::debug!("Raw JSON: {}", body_text);
                     Err(HeliusError::from(e))
                 }
             }

--- a/src/rpc_client.rs
+++ b/src/rpc_client.rs
@@ -379,7 +379,7 @@ impl RpcClient {
                 self.get_program_accounts_v2(program_id.clone(), config.clone()).await?;
             all_accounts.extend(response.accounts);
 
-            println!("Fetched {} accounts so far", all_accounts.len());
+            log::info!("Fetched {} accounts so far", all_accounts.len());
 
             if let Some(key) = response.pagination_key {
                 config.pagination_key = Some(key);

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -185,9 +185,10 @@ impl EnhancedWebsocket {
             UnboundedReceiverStream::new(notifications)
                 .filter_map(|value| match serde_json::from_value::<T>(value.clone()) {
                     Err(e) => {
-                        eprintln!(
+                        log::warn!(
                             "Failed to parse websocket notification: {:#?} for value: {:#?}",
-                            e, value
+                            e,
+                            value
                         );
                         ready(None)
                     }
@@ -429,7 +430,7 @@ impl EnhancedWebsocket {
                       }
                     }
                   } else {
-                      eprintln!("Unknown request id: {}", id);
+                      log::warn!("Unknown request id: {}", id);
                       break;
                   }
                   continue;


### PR DESCRIPTION
## Summary
- Adds the `log` crate as a dependency
- Replaces all `println!`/`eprintln!` calls in library code with appropriate `log` macros (`info!`, `warn!`, `error!`, `debug!`)
- Consumers using `tracing`, `env_logger`, or any `log`-compatible subscriber can now capture SDK diagnostics as structured log events instead of raw stdout/stderr output

Closes #184

## Test plan
- [x] `cargo build --release` passes
- [x] `cargo test` — all 29 tests pass
- [x] `cargo fmt` — no changes needed
- [x] `cargo clippy` — clean (only pre-existing deprecation warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)