### PR TITLE
feat(types): Add Typed Responses for gTFA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - `TransactionSignatureEntry` struct with typed fields (`signature`, `slot`, `transaction_index`, `err`, `memo`, `block_time`, `confirmation_status`) for the `signatures` response mode of `getTransactionsForAddress`
-- `TransactionEntry` enum with `Signature` and `Full` variants; the `Full` variant reuses `EncodedTransactionWithStatusMeta` from `solana-transaction-status`
+- `FullTransactionEntry` struct with typed fields (`slot`, `transaction_index`, `transaction`, `meta`, `block_time`) for the `full` response mode, matching the Helius OpenAPI spec
+- `TransactionEntry` enum with `Signature`, `Full`, and `Unknown` variants for type-safe access with a fallback for forward compatibility
 
 ### Changed
 - **Breaking**: `GetTransactionsForAddressResponse.data` changed from `Vec<serde_json::Value>` to `Vec<TransactionEntry>`, providing typed access to transaction data instead of raw JSON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-03-25
+
+### Added
+- `TransactionSignatureEntry` struct with typed fields (`signature`, `slot`, `transaction_index`, `err`, `memo`, `block_time`, `confirmation_status`) for the `signatures` response mode of `getTransactionsForAddress`
+- `TransactionEntry` enum with `Signature` and `Full` variants; the `Full` variant reuses `EncodedTransactionWithStatusMeta` from `solana-transaction-status`
+
+### Changed
+- **Breaking**: `GetTransactionsForAddressResponse.data` changed from `Vec<serde_json::Value>` to `Vec<TransactionEntry>`, providing typed access to transaction data instead of raw JSON
+
 ## [1.0.1] - 2026-03-20
 
 ### Changed
@@ -192,7 +201,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Integration test suite using `mockito`
 - GitHub Actions CI workflow
 
-[Unreleased]: https://github.com/helius-labs/helius-rust-sdk/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/helius-labs/helius-rust-sdk/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/helius-labs/helius-rust-sdk/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/helius-labs/helius-rust-sdk/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/helius-labs/helius-rust-sdk/compare/v0.5.1...v1.0.0
 [0.5.1]: https://github.com/helius-labs/helius-rust-sdk/compare/v0.5.0...v0.5.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helius"
-version = "1.0.1"
+version = "1.1.0"
 rust-version = "1.85.1"
 edition = "2021"
 description = "An asynchronous Helius Rust SDK for building the future of Solana"

--- a/examples/enhanced/get_transactions_for_address.rs
+++ b/examples/enhanced/get_transactions_for_address.rs
@@ -1,6 +1,6 @@
 use helius::error::Result;
-use helius::types::inner::TransactionDetails;
-use helius::types::{Cluster, GetTransactionsForAddressOptions, GetTransactionsForAddressResponse};
+use helius::types::inner::{TransactionDetails, TransactionEntry};
+use helius::types::{Cluster, GetTransactionsForAddressOptions};
 use helius::Helius;
 
 #[tokio::main]
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
     );
     println!();
 
-    let response: Result<GetTransactionsForAddressResponse> = helius
+    let response = helius
         .rpc()
         .get_transactions_for_address(address.to_string(), options)
         .await;
@@ -36,8 +36,19 @@ async fn main() -> Result<()> {
             println!("Successfully fetched {} transactions", result.data.len());
             println!();
 
-            for (i, tx) in result.data.iter().enumerate() {
-                println!("Transaction #{}: {}", i + 1, serde_json::to_string_pretty(tx).unwrap());
+            for (i, entry) in result.data.iter().enumerate() {
+                match entry {
+                    TransactionEntry::Signature(sig) => {
+                        println!("Transaction #{}", i + 1);
+                        println!("  Signature: {}", sig.signature);
+                        println!("  Slot: {}", sig.slot);
+                        println!("  Block time: {:?}", sig.block_time);
+                        println!("  Status: {:?}", sig.confirmation_status);
+                    }
+                    TransactionEntry::Full(tx) => {
+                        println!("Transaction #{}: {:?}", i + 1, tx);
+                    }
+                }
             }
 
             if let Some(token) = result.pagination_token {

--- a/examples/enhanced/get_transactions_for_address.rs
+++ b/examples/enhanced/get_transactions_for_address.rs
@@ -46,7 +46,10 @@ async fn main() -> Result<()> {
                         println!("  Status: {:?}", sig.confirmation_status);
                     }
                     TransactionEntry::Full(tx) => {
-                        println!("Transaction #{}: {:?}", i + 1, tx);
+                        println!("Transaction #{}", i + 1);
+                        println!("  Slot: {}", tx.slot);
+                        println!("  Block time: {:?}", tx.block_time);
+                        println!("  Has meta: {}", tx.meta.is_some());
                     }
                     TransactionEntry::Unknown(val) => {
                         println!("Transaction #{} (unknown format): {}", i + 1, val);

--- a/examples/enhanced/get_transactions_for_address.rs
+++ b/examples/enhanced/get_transactions_for_address.rs
@@ -48,6 +48,9 @@ async fn main() -> Result<()> {
                     TransactionEntry::Full(tx) => {
                         println!("Transaction #{}: {:?}", i + 1, tx);
                     }
+                    TransactionEntry::Unknown(val) => {
+                        println!("Transaction #{} (unknown format): {}", i + 1, val);
+                    }
                 }
             }
 

--- a/examples/enhanced/get_transactions_for_address_with_filters.rs
+++ b/examples/enhanced/get_transactions_for_address_with_filters.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
             for (i, entry) in result.data.iter().enumerate() {
                 match entry {
                     TransactionEntry::Full(tx) => {
-                        println!("  {}. version={:?}, has_meta={}", i + 1, tx.version, tx.meta.is_some());
+                        println!("  {}. slot={}, has_meta={}", i + 1, tx.slot, tx.meta.is_some());
                     }
                     TransactionEntry::Signature(sig) => {
                         println!("  {}. {}", i + 1, sig.signature);

--- a/examples/enhanced/get_transactions_for_address_with_filters.rs
+++ b/examples/enhanced/get_transactions_for_address_with_filters.rs
@@ -1,6 +1,7 @@
 use helius::error::Result;
 use helius::types::inner::{
-    GetTransactionsFilters, SlotFilter, TokenAccountsFilter, TransactionDetails, TransactionStatusFilter,
+    GetTransactionsFilters, SlotFilter, TokenAccountsFilter, TransactionDetails, TransactionEntry,
+    TransactionStatusFilter,
 };
 use helius::types::{Cluster, GetTransactionsForAddressOptions, SortOrder};
 use helius::Helius;
@@ -13,7 +14,7 @@ async fn main() -> Result<()> {
 
     let address = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
 
-    println!("=== Example 1: Recent successful transactions ===");
+    println!("=== Example 1: Recent successful transactions (full) ===");
     let options = GetTransactionsForAddressOptions {
         limit: Some(10),
         transaction_details: Some(TransactionDetails::Full),
@@ -32,6 +33,16 @@ async fn main() -> Result<()> {
     {
         Ok(result) => {
             println!("Fetched {} successful transactions", result.data.len());
+            for (i, entry) in result.data.iter().enumerate() {
+                match entry {
+                    TransactionEntry::Full(tx) => {
+                        println!("  {}. version={:?}, has_meta={}", i + 1, tx.version, tx.meta.is_some());
+                    }
+                    TransactionEntry::Signature(sig) => {
+                        println!("  {}. {}", i + 1, sig.signature);
+                    }
+                }
+            }
             println!("Pagination token: {:?}", result.pagination_token);
         }
         Err(e) => println!("Error: {:?}", e),
@@ -61,8 +72,16 @@ async fn main() -> Result<()> {
     {
         Ok(result) => {
             println!("Fetched {} transactions in slot range", result.data.len());
-            for (i, tx) in result.data.iter().enumerate() {
-                println!("  {}. {:?}", i + 1, tx);
+            for (i, entry) in result.data.iter().enumerate() {
+                if let TransactionEntry::Signature(sig) = entry {
+                    println!(
+                        "  {}. sig={}, slot={}, block_time={:?}",
+                        i + 1,
+                        sig.signature,
+                        sig.slot,
+                        sig.block_time
+                    );
+                }
             }
         }
         Err(e) => println!("Error: {:?}", e),
@@ -88,6 +107,11 @@ async fn main() -> Result<()> {
     {
         Ok(result) => {
             println!("Fetched {} failed transactions", result.data.len());
+            for (i, entry) in result.data.iter().enumerate() {
+                if let TransactionEntry::Signature(sig) = entry {
+                    println!("  {}. sig={}, err={:?}", i + 1, sig.signature, sig.err);
+                }
+            }
         }
         Err(e) => println!("Error: {:?}", e),
     }
@@ -143,6 +167,11 @@ async fn main() -> Result<()> {
         {
             Ok(result) => {
                 println!("Page {}: {} transactions", page, result.data.len());
+                for entry in &result.data {
+                    if let TransactionEntry::Signature(sig) = entry {
+                        println!("  - {} (slot {})", sig.signature, sig.slot);
+                    }
+                }
 
                 if let Some(token) = result.pagination_token {
                     pagination_token = Some(token);

--- a/examples/enhanced/get_transactions_for_address_with_filters.rs
+++ b/examples/enhanced/get_transactions_for_address_with_filters.rs
@@ -41,6 +41,9 @@ async fn main() -> Result<()> {
                     TransactionEntry::Signature(sig) => {
                         println!("  {}. {}", i + 1, sig.signature);
                     }
+                    TransactionEntry::Unknown(val) => {
+                        println!("  {}. (unknown format): {}", i + 1, val);
+                    }
                 }
             }
             println!("Pagination token: {:?}", result.pagination_token);

--- a/llms.txt
+++ b/llms.txt
@@ -658,11 +658,11 @@ tokio::spawn(async move {
 ```toml
 # Default: native TLS (OpenSSL)
 [dependencies]
-helius = "1.0"
+helius = "1.1"
 
 # Alternative: rustls (pure Rust, no OpenSSL dependency)
 [dependencies]
-helius = { version = "1.0", default-features = false, features = ["rustls"] }
+helius = { version = "1.1", default-features = false, features = ["rustls"] }
 ```
 
 ## Plans and Rate Limits

--- a/src/types/inner.rs
+++ b/src/types/inner.rs
@@ -12,6 +12,7 @@ use std::time::Duration;
 use solana_client::rpc_config::RpcSendTransactionConfig;
 use solana_commitment_config::CommitmentLevel;
 use solana_sdk::{instruction::Instruction, message::AddressLookupTableAccount, signature::Signer};
+use solana_transaction_status::EncodedTransactionWithStatusMeta;
 
 /// Defines the available clusters supported by Helius
 #[derive(Debug, Clone, PartialEq)]
@@ -2479,19 +2480,76 @@ pub struct GetTransactionsForAddressOptions {
     pub min_context_slot: Option<u64>,
 }
 
+/// A transaction entry returned in "signatures" mode from `getTransactionsForAddress`.
+///
+/// Contains the transaction signature along with slot, timing, and status metadata.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct TransactionSignatureEntry {
+    /// The transaction signature (base-58 encoded)
+    pub signature: String,
+    /// The slot in which the transaction was processed
+    pub slot: u64,
+    /// Position of the transaction within the block
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transaction_index: Option<u64>,
+    /// Transaction error, if any (Solana runtime error format)
+    pub err: Option<serde_json::Value>,
+    /// Memo associated with the transaction, if any
+    pub memo: Option<String>,
+    /// Estimated block production time as a Unix timestamp (seconds since epoch)
+    pub block_time: Option<i64>,
+    /// The transaction's confirmation status
+    pub confirmation_status: Option<String>,
+}
+
+/// A single transaction entry from `getTransactionsForAddress`.
+///
+/// The variant depends on the `transaction_details` option:
+/// - [`TransactionDetails::Signatures`]: deserializes as [`TransactionEntry::Signature`]
+/// - [`TransactionDetails::Full`]: deserializes as [`TransactionEntry::Full`]
+///
+/// If the API returns a shape that doesn't match either known variant,
+/// [`TransactionEntry::Unknown`] captures the raw JSON so deserialization
+/// never fails silently.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(untagged)]
+pub enum TransactionEntry {
+    /// Full transaction data with instructions, metadata, and version info
+    Full(Box<EncodedTransactionWithStatusMeta>),
+    /// Lightweight signature entry with slot, timing, and status metadata
+    Signature(TransactionSignatureEntry),
+    /// Fallback for unrecognized response shapes (e.g., new API modes)
+    Unknown(serde_json::Value),
+}
+
+impl Default for TransactionEntry {
+    fn default() -> Self {
+        TransactionEntry::Signature(TransactionSignatureEntry {
+            signature: String::new(),
+            slot: 0,
+            transaction_index: None,
+            err: None,
+            memo: None,
+            block_time: None,
+            confirmation_status: None,
+        })
+    }
+}
+
 /// Response from `getTransactionsForAddress`.
 ///
 /// Contains a page of transaction data and an optional pagination cursor. The format
 /// of items in `data` depends on the `transaction_details` setting:
-/// - `Signatures`: each item is a transaction signature string
-/// - `Full`: each item is a full transaction object
+/// - `Signatures`: each item is a [`TransactionEntry::Signature`]
+/// - `Full`: each item is a [`TransactionEntry::Full`]
 ///
 /// When `pagination_token` is `None`, all results have been returned.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct GetTransactionsForAddressResponse {
     /// Transaction data for this page (signatures or full transactions depending on options)
-    pub data: Vec<serde_json::Value>,
+    pub data: Vec<TransactionEntry>,
     /// Cursor for the next page; `None` when no more results remain
     pub pagination_token: Option<String>,
 }

--- a/src/types/inner.rs
+++ b/src/types/inner.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use solana_client::rpc_config::RpcSendTransactionConfig;
 use solana_commitment_config::CommitmentLevel;
 use solana_sdk::{instruction::Instruction, message::AddressLookupTableAccount, signature::Signer};
-use solana_transaction_status::EncodedTransactionWithStatusMeta;
+use solana_transaction_status::{EncodedTransaction, UiTransactionStatusMeta};
 
 /// Defines the available clusters supported by Helius
 #[derive(Debug, Clone, PartialEq)]
@@ -2503,6 +2503,27 @@ pub struct TransactionSignatureEntry {
     pub confirmation_status: Option<String>,
 }
 
+/// A transaction entry returned in "full" mode from `getTransactionsForAddress`.
+///
+/// Contains the full transaction data along with block-level metadata like slot,
+/// transaction index, and block time.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct FullTransactionEntry {
+    /// The slot in which the transaction was processed
+    pub slot: u64,
+    /// Position of the transaction within the block
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub transaction_index: Option<u64>,
+    /// The encoded transaction object
+    pub transaction: EncodedTransaction,
+    /// Transaction status metadata (fees, balances, logs, etc.)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub meta: Option<UiTransactionStatusMeta>,
+    /// Estimated block production time as a Unix timestamp (seconds since epoch)
+    pub block_time: Option<i64>,
+}
+
 /// A single transaction entry from `getTransactionsForAddress`.
 ///
 /// The variant depends on the `transaction_details` option:
@@ -2515,8 +2536,8 @@ pub struct TransactionSignatureEntry {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum TransactionEntry {
-    /// Full transaction data with instructions, metadata, and version info
-    Full(Box<EncodedTransactionWithStatusMeta>),
+    /// Full transaction data with block-level metadata
+    Full(Box<FullTransactionEntry>),
     /// Lightweight signature entry with slot, timing, and status metadata
     Signature(TransactionSignatureEntry),
     /// Fallback for unrecognized response shapes (e.g., new API modes)

--- a/tests/rpc/test_get_transactions_for_address.rs
+++ b/tests/rpc/test_get_transactions_for_address.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use helius::client::Helius;
 use helius::config::Config;
 use helius::rpc_client::RpcClient;
-use helius::types::inner::TransactionDetails;
+use helius::types::inner::{TransactionDetails, TransactionEntry};
 use helius::types::*;
 
 use mockito::{self, Server};
@@ -80,6 +80,205 @@ async fn test_get_transactions_for_address_success() {
     assert_eq!(result.data.len(), 1);
     assert_eq!(result.pagination_token, Some("1055:5".to_string()));
 
-    let first_tx = &result.data[0];
-    assert_eq!(first_tx["slot"], 1054);
+    match &result.data[0] {
+        TransactionEntry::Signature(entry) => {
+            assert_eq!(entry.slot, 1054);
+            assert_eq!(
+                entry.signature,
+                "5h6xBEauJ3PK6SWCZ1PGjBvj8vDdWG3KpwATGy1ARAXFSDwt8GFXM7W5Ncn16wmqokgpiKRLuS83KUxyZyv2sUYv"
+            );
+            assert_eq!(entry.block_time, Some(1641038400));
+            assert_eq!(entry.confirmation_status, Some("finalized".to_string()));
+            assert!(entry.err.is_none());
+            assert!(entry.memo.is_none());
+        }
+        TransactionEntry::Full(_) => panic!("Expected Signature variant, got Full"),
+        TransactionEntry::Unknown(_) => panic!("Expected Signature variant, got Unknown"),
+    }
+}
+
+#[tokio::test]
+async fn test_get_transactions_for_address_full_success() {
+    let mut server = Server::new_with_opts_async(mockito::ServerOpts::default()).await;
+    let url = server.url();
+
+    // Mock a full transaction response (matches EncodedTransactionWithStatusMeta shape)
+    let mock_data = json!([
+        {
+            "transaction": {
+                "signatures": [
+                    "5h6xBEauJ3PK6SWCZ1PGjBvj8vDdWG3KpwATGy1ARAXFSDwt8GFXM7W5Ncn16wmqokgpiKRLuS83KUxyZyv2sUYv"
+                ],
+                "message": {
+                    "accountKeys": [
+                        "83astBRguLMdt2h5U1Tpdq5tjFoJ6noeGwaY3mDLVcri",
+                        "11111111111111111111111111111111"
+                    ],
+                    "header": {
+                        "numReadonlySignedAccounts": 0,
+                        "numReadonlyUnsignedAccounts": 1,
+                        "numRequiredSignatures": 1
+                    },
+                    "instructions": [
+                        {
+                            "accounts": [0, 1],
+                            "data": "3Bxs4ThwQbE4vyj5",
+                            "programIdIndex": 1
+                        }
+                    ],
+                    "recentBlockhash": "GeyAMqaSPnLV7LPY8ByVNvZmhFBvAsGagsby35sBvSfN"
+                }
+            },
+            "meta": {
+                "err": null,
+                "status": { "Ok": null },
+                "fee": 5000,
+                "preBalances": [1000000000, 0],
+                "postBalances": [999995000, 0],
+                "innerInstructions": [],
+                "logMessages": ["Program 11111111111111111111111111111111 invoke [1]"],
+                "preTokenBalances": [],
+                "postTokenBalances": [],
+                "rewards": []
+            },
+            "version": "legacy"
+        }
+    ]);
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "id": "helius-rust-sdk",
+        "result": {
+            "data": mock_data,
+            "paginationToken": null
+        }
+    });
+
+    server
+        .mock("POST", "/?api-key=fake_api_key")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create();
+
+    let config = Arc::new(Config {
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
+        cluster: Cluster::Devnet,
+        endpoints: HeliusEndpoints {
+            api: url.to_string(),
+            rpc: url.to_string(),
+        },
+        custom_url: None,
+    });
+
+    let client = Client::new();
+    let rpc_client = Arc::new(RpcClient::new(Arc::new(client.clone()), Arc::clone(&config)).unwrap());
+    let helius = Helius {
+        config,
+        client,
+        rpc_client,
+        async_rpc_client: None,
+        ws_client: None,
+    };
+
+    let options = GetTransactionsForAddressOptions {
+        limit: Some(10),
+        transaction_details: Some(TransactionDetails::Full),
+        ..Default::default()
+    };
+
+    let response = helius
+        .rpc()
+        .get_transactions_for_address("SomeAddress".to_string(), options)
+        .await;
+
+    assert!(response.is_ok(), "API call failed with error: {:?}", response.err());
+
+    let result = response.unwrap();
+    assert_eq!(result.data.len(), 1);
+    assert!(result.pagination_token.is_none());
+
+    match &result.data[0] {
+        TransactionEntry::Full(tx) => {
+            assert!(tx.meta.is_some());
+            let meta = tx.meta.as_ref().unwrap();
+            assert!(meta.err.is_none());
+        }
+        TransactionEntry::Signature(_) => panic!("Expected Full variant, got Signature"),
+        TransactionEntry::Unknown(_) => panic!("Expected Full variant, got Unknown"),
+    }
+}
+
+#[tokio::test]
+async fn test_get_transactions_for_address_unknown_fallback() {
+    let mut server = Server::new_with_opts_async(mockito::ServerOpts::default()).await;
+    let url = server.url();
+
+    // Mock a response with an unrecognized shape (e.g., a hypothetical new API mode)
+    let mock_data = json!([
+        {
+            "someNewField": "unexpected_data",
+            "anotherField": 42
+        }
+    ]);
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "id": "helius-rust-sdk",
+        "result": {
+            "data": mock_data,
+            "paginationToken": null
+        }
+    });
+
+    server
+        .mock("POST", "/?api-key=fake_api_key")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create();
+
+    let config = Arc::new(Config {
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
+        cluster: Cluster::Devnet,
+        endpoints: HeliusEndpoints {
+            api: url.to_string(),
+            rpc: url.to_string(),
+        },
+        custom_url: None,
+    });
+
+    let client = Client::new();
+    let rpc_client = Arc::new(RpcClient::new(Arc::new(client.clone()), Arc::clone(&config)).unwrap());
+    let helius = Helius {
+        config,
+        client,
+        rpc_client,
+        async_rpc_client: None,
+        ws_client: None,
+    };
+
+    let options = GetTransactionsForAddressOptions {
+        limit: Some(10),
+        ..Default::default()
+    };
+
+    let response = helius
+        .rpc()
+        .get_transactions_for_address("SomeAddress".to_string(), options)
+        .await;
+
+    assert!(response.is_ok(), "API call failed with error: {:?}", response.err());
+
+    let result = response.unwrap();
+    assert_eq!(result.data.len(), 1);
+
+    match &result.data[0] {
+        TransactionEntry::Unknown(val) => {
+            assert_eq!(val["someNewField"], "unexpected_data");
+            assert_eq!(val["anotherField"], 42);
+        }
+        TransactionEntry::Signature(_) => panic!("Expected Unknown variant, got Signature"),
+        TransactionEntry::Full(_) => panic!("Expected Unknown variant, got Full"),
+    }
 }

--- a/tests/rpc/test_get_transactions_for_address.rs
+++ b/tests/rpc/test_get_transactions_for_address.rs
@@ -102,9 +102,11 @@ async fn test_get_transactions_for_address_full_success() {
     let mut server = Server::new_with_opts_async(mockito::ServerOpts::default()).await;
     let url = server.url();
 
-    // Mock a full transaction response (matches EncodedTransactionWithStatusMeta shape)
+    // Mock a full transaction response (matches getTransactionsForAddress full mode)
     let mock_data = json!([
         {
+            "slot": 1054,
+            "transactionIndex": 42,
             "transaction": {
                 "signatures": [
                     "5h6xBEauJ3PK6SWCZ1PGjBvj8vDdWG3KpwATGy1ARAXFSDwt8GFXM7W5Ncn16wmqokgpiKRLuS83KUxyZyv2sUYv"
@@ -141,7 +143,7 @@ async fn test_get_transactions_for_address_full_success() {
                 "postTokenBalances": [],
                 "rewards": []
             },
-            "version": "legacy"
+            "blockTime": 1641038400
         }
     ]);
 
@@ -200,6 +202,9 @@ async fn test_get_transactions_for_address_full_success() {
 
     match &result.data[0] {
         TransactionEntry::Full(tx) => {
+            assert_eq!(tx.slot, 1054);
+            assert_eq!(tx.transaction_index, Some(42));
+            assert_eq!(tx.block_time, Some(1641038400));
             assert!(tx.meta.is_some());
             let meta = tx.meta.as_ref().unwrap();
             assert!(meta.err.is_none());


### PR DESCRIPTION
This PR replaces `Vec<serde_json::Value>` with `Vec<TransactionEntry` in `GetTransactionsForAddressResponse`, so users get typed field access instead of raw JSON

Note that `GetTransactionsForAddressResponse.data` is now `Vec<TransactionEntry>`, meaning that users accessing fields via JSON indexing (e.g., `data[0]["slot"]`) now need to pattern match since gTFA gives different responses based on whether the user requests full transaction details or just signatures 