### PR TITLE
fix(types): Make `transaction_index` Required

### DIFF
--- a/src/types/inner.rs
+++ b/src/types/inner.rs
@@ -2490,9 +2490,8 @@ pub struct TransactionSignatureEntry {
     pub signature: String,
     /// The slot in which the transaction was processed
     pub slot: u64,
-    /// Position of the transaction within the block
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub transaction_index: Option<u64>,
+    /// Zero-based position of the transaction within its block
+    pub transaction_index: u64,
     /// Transaction error, if any (Solana runtime error format)
     pub err: Option<serde_json::Value>,
     /// Memo associated with the transaction, if any
@@ -2512,9 +2511,8 @@ pub struct TransactionSignatureEntry {
 pub struct FullTransactionEntry {
     /// The slot in which the transaction was processed
     pub slot: u64,
-    /// Position of the transaction within the block
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub transaction_index: Option<u64>,
+    /// Zero-based position of the transaction within its block
+    pub transaction_index: u64,
     /// The encoded transaction object
     pub transaction: EncodedTransaction,
     /// Transaction status metadata (fees, balances, logs, etc.)
@@ -2549,7 +2547,7 @@ impl Default for TransactionEntry {
         TransactionEntry::Signature(TransactionSignatureEntry {
             signature: String::new(),
             slot: 0,
-            transaction_index: None,
+            transaction_index: 0,
             err: None,
             memo: None,
             block_time: None,

--- a/tests/rpc/test_get_transactions_for_address.rs
+++ b/tests/rpc/test_get_transactions_for_address.rs
@@ -20,6 +20,7 @@ async fn test_get_transactions_for_address_success() {
         {
             "signature": "5h6xBEauJ3PK6SWCZ1PGjBvj8vDdWG3KpwATGy1ARAXFSDwt8GFXM7W5Ncn16wmqokgpiKRLuS83KUxyZyv2sUYv",
             "slot": 1054,
+            "transactionIndex": 7,
             "err": null,
             "memo": null,
             "blockTime": 1641038400,
@@ -203,7 +204,7 @@ async fn test_get_transactions_for_address_full_success() {
     match &result.data[0] {
         TransactionEntry::Full(tx) => {
             assert_eq!(tx.slot, 1054);
-            assert_eq!(tx.transaction_index, Some(42));
+            assert_eq!(tx.transaction_index, 42);
             assert_eq!(tx.block_time, Some(1641038400));
             assert!(tx.meta.is_some());
             let meta = tx.meta.as_ref().unwrap();


### PR DESCRIPTION
This is a quick PR to make `transaction_index` required in the response, as it is always present and not optional