### PR TITLE
make transactionSubscribe output the proper type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- `FullTransactionNotification` struct for full-mode `transactionSubscribe` payloads, including `transaction`, `signature`, `slot`, and `transaction_index`
+
+### Changed
+- **Breaking**: `TransactionNotification` changed from a struct to an enum with `Full`, `Signature`, and `Unknown` variants to support all `transactionSubscribe` detail modes. Code that accessed `event.signature` or `event.transaction` directly must now match on the variant first.
+
+### Fixed
+- `transactionSubscribe` with `transactionDetails: "signatures"` no longer causes a decode error due to the missing `transaction` field
+
 ## [1.1.0] - 2026-03-25
 
 ### Added

--- a/src/types/enhanced_websocket.rs
+++ b/src/types/enhanced_websocket.rs
@@ -1,4 +1,6 @@
+use super::inner::TransactionSignatureEntry;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use solana_sdk::pubkey::Pubkey;
 use solana_transaction_status::EncodedTransactionWithStatusMeta;
 
@@ -137,17 +139,54 @@ pub struct RpcTransactionsConfig {
     pub options: TransactionSubscribeOptions,
 }
 
-/// A real-time transaction notification received from a `transactionSubscribe` subscription.
+/// A transaction notification returned in `"full"` mode from `transactionSubscribe`.
 ///
-/// Delivered whenever a transaction matching the subscription filter is observed at the
-/// configured commitment level.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// Contains the websocket-specific full transaction payload, including the top-level signature
+/// and the transaction index within the slot.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct TransactionNotification {
-    /// The full encoded transaction with status metadata
+pub struct FullTransactionNotification {
+    /// The full encoded transaction with status metadata.
     pub transaction: EncodedTransactionWithStatusMeta,
-    /// The transaction signature (base-58 encoded)
+    /// The transaction signature (base-58 encoded).
     pub signature: String,
-    /// The slot in which the transaction was processed
+    /// The slot in which the transaction was processed.
     pub slot: u64,
+    /// Zero-based position of the transaction within its block.
+    pub transaction_index: u64,
+}
+
+/// A single transaction notification from `transactionSubscribe`.
+///
+/// The variant depends on the `transaction_details` option:
+/// - [`TransactionDetails::Signatures`]: deserializes as [`TransactionNotification::Signature`]
+/// - [`TransactionDetails::Full`] and [`TransactionDetails::Accounts`]: deserializes as
+///   [`TransactionNotification::Full`]
+///
+/// If the API returns a shape that doesn't match a known variant,
+/// [`TransactionNotification::Unknown`] captures the raw JSON so deserialization
+/// never fails silently.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum TransactionNotification {
+    /// Full websocket transaction notification with the encoded transaction payload.
+    Full(Box<FullTransactionNotification>),
+    /// Lightweight signature notification with slot metadata only.
+    Signature(TransactionSignatureEntry),
+    /// Fallback for unrecognized response shapes (e.g. future API modes).
+    Unknown(Value),
+}
+
+impl Default for TransactionNotification {
+    fn default() -> Self {
+        TransactionNotification::Signature(TransactionSignatureEntry {
+            signature: String::new(),
+            slot: 0,
+            transaction_index: 0,
+            err: None,
+            memo: None,
+            block_time: None,
+            confirmation_status: None,
+        })
+    }
 }

--- a/src/types/enhanced_websocket.rs
+++ b/src/types/enhanced_websocket.rs
@@ -166,6 +166,11 @@ pub struct FullTransactionNotification {
 /// If the API returns a shape that doesn't match a known variant,
 /// [`TransactionNotification::Unknown`] captures the raw JSON so deserialization
 /// never fails silently.
+///
+/// **Variant ordering matters:** serde tries `untagged` variants top-down.
+/// `Full` must precede `Signature` because `Signature` would also match a full
+/// payload (its extra fields are simply ignored). Reordering the variants will
+/// cause full notifications to silently deserialize as `Signature`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum TransactionNotification {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -7,8 +7,8 @@ pub mod zk_compression_types;
 
 pub use self::enhanced_transaction_types::*;
 pub use self::enhanced_websocket::{
-    RpcTransactionsConfig, TransactionCommitment, TransactionNotification, TransactionSubscribeFilter,
-    TransactionSubscribeOptions, UiEnhancedTransactionEncoding,
+    FullTransactionNotification, RpcTransactionsConfig, TransactionCommitment, TransactionNotification,
+    TransactionSubscribeFilter, TransactionSubscribeOptions, UiEnhancedTransactionEncoding,
 };
 pub use self::enums::*;
 pub use self::inner::*;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -47,6 +47,7 @@ mod smart_transactions {
 }
 mod websocket {
     mod test_get_url;
+    mod test_transaction_subscribe;
     mod test_websocket_lifecycle;
 }
 mod staking {

--- a/tests/websocket/test_transaction_subscribe.rs
+++ b/tests/websocket/test_transaction_subscribe.rs
@@ -1,0 +1,241 @@
+use futures_util::{SinkExt, StreamExt};
+use helius::types::{
+    enhanced_websocket::TransactionDetails, RpcTransactionsConfig, TransactionCommitment, TransactionNotification,
+    TransactionSubscribeFilter, TransactionSubscribeOptions, UiEnhancedTransactionEncoding,
+};
+use helius::websocket::EnhancedWebsocket;
+use serde_json::{json, Value};
+use tokio::net::TcpListener;
+use tokio::time::{timeout, Duration};
+use tokio_tungstenite::{accept_async, tungstenite::Message};
+
+async fn start_mock_ws_server(transaction_notification: Value) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let url = format!("ws://{}", addr);
+
+    tokio::spawn(async move {
+        if let Ok((stream, _)) = listener.accept().await {
+            let mut ws = accept_async(stream).await.unwrap();
+
+            while let Some(Ok(msg)) = ws.next().await {
+                match msg {
+                    Message::Text(text) => {
+                        let request: Value = serde_json::from_str(&text).unwrap();
+                        let id = request.get("id").and_then(Value::as_u64).unwrap();
+                        let method = request.get("method").and_then(Value::as_str).unwrap();
+
+                        match method {
+                            "transactionSubscribe" => {
+                                let ack = json!({
+                                    "jsonrpc": "2.0",
+                                    "result": 1,
+                                    "id": id
+                                });
+                                ws.send(Message::Text(ack.to_string().into())).await.unwrap();
+
+                                let notification = json!({
+                                    "jsonrpc": "2.0",
+                                    "method": "transactionNotification",
+                                    "params": {
+                                        "result": transaction_notification,
+                                        "subscription": 1
+                                    }
+                                });
+                                ws.send(Message::Text(notification.to_string().into())).await.unwrap();
+                            }
+                            "transactionUnsubscribe" => {
+                                let response = json!({
+                                    "jsonrpc": "2.0",
+                                    "result": true,
+                                    "id": id
+                                });
+                                ws.send(Message::Text(response.to_string().into())).await.unwrap();
+                                let _ = ws.close(None).await;
+                                break;
+                            }
+                            _ => {}
+                        }
+                    }
+                    Message::Close(_) => {
+                        let _ = ws.close(None).await;
+                        break;
+                    }
+                    Message::Ping(data) => {
+                        let _ = ws.send(Message::Pong(data)).await;
+                    }
+                    _ => {}
+                }
+            }
+        }
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    url
+}
+
+fn subscription_config(details: TransactionDetails) -> RpcTransactionsConfig {
+    RpcTransactionsConfig {
+        filter: TransactionSubscribeFilter {
+            account_include: Some(vec!["7Yf2QH4w9mK3rT6uV8xZ1cD5eF7gH9jK2LmN4pQ6sTuW".to_string()]),
+            vote: Some(false),
+            failed: Some(false),
+            signature: None,
+            account_exclude: None,
+            account_required: None,
+        },
+        options: TransactionSubscribeOptions {
+            commitment: Some(TransactionCommitment::Confirmed),
+            encoding: Some(UiEnhancedTransactionEncoding::Base64),
+            transaction_details: Some(details),
+            show_rewards: Some(false),
+            max_supported_transaction_version: Some(0),
+        },
+    }
+}
+
+#[tokio::test]
+async fn transaction_subscribe_decodes_signature_notifications() {
+    let url = start_mock_ws_server(json!({
+        "signature": "3Tf7QH4w9mK3rT6uV8xZ1cD5eF7gH9jK2LmN4pQ6sTuW8XaB2cDe4Fg6Hj8Km9Np2Qr4St6Uv8Wx7Yz2aBc4DeF6",
+        "slot": 123456u64,
+        "transactionIndex": 17u64
+    }))
+    .await;
+
+    let ws = EnhancedWebsocket::new(&url, Some(30), None).await.unwrap();
+    let (mut stream, _unsub) = ws
+        .transaction_subscribe(subscription_config(TransactionDetails::Signatures))
+        .await
+        .unwrap();
+
+    let event = timeout(Duration::from_secs(2), stream.next())
+        .await
+        .expect("timed out waiting for signature notification")
+        .expect("stream ended before signature notification");
+
+    match event {
+        TransactionNotification::Signature(entry) => {
+            assert_eq!(entry.slot, 123456);
+            assert_eq!(entry.transaction_index, 17);
+            assert_eq!(
+                entry.signature,
+                "3Tf7QH4w9mK3rT6uV8xZ1cD5eF7gH9jK2LmN4pQ6sTuW8XaB2cDe4Fg6Hj8Km9Np2Qr4St6Uv8Wx7Yz2aBc4DeF6"
+            );
+        }
+        other => panic!("expected signature notification, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn transaction_subscribe_decodes_full_notifications() {
+    let url = start_mock_ws_server(json!({
+        "signature": "5Gh8Jk2LmN4pQ6sTuW8XaB2cDe4Fg6Hj8Km9Np2Qr4St6Uv8Wx7Yz2aBc4DeF6Gh7Jk9Lm2Np4Qr6St8Uv2Wx4Yz",
+        "slot": 123457u64,
+        "transactionIndex": 18u64,
+        "transaction": {
+            "meta": {
+                "err": null,
+                "fee": 1005000u64,
+                "preBalances": [1, 2, 3],
+                "postBalances": [1, 2, 3],
+                "status": { "Ok": null }
+            },
+            "transaction": [
+                "AQ==",
+                "base64"
+            ],
+            "version": 0
+        }
+    }))
+    .await;
+
+    let ws = EnhancedWebsocket::new(&url, Some(30), None).await.unwrap();
+    let (mut stream, _unsub) = ws
+        .transaction_subscribe(subscription_config(TransactionDetails::Full))
+        .await
+        .unwrap();
+
+    let event = timeout(Duration::from_secs(2), stream.next())
+        .await
+        .expect("timed out waiting for full notification")
+        .expect("stream ended before full notification");
+
+    match event {
+        TransactionNotification::Full(entry) => {
+            assert_eq!(entry.slot, 123457);
+            assert_eq!(entry.transaction_index, 18);
+            assert_eq!(
+                entry.signature,
+                "5Gh8Jk2LmN4pQ6sTuW8XaB2cDe4Fg6Hj8Km9Np2Qr4St6Uv8Wx7Yz2aBc4DeF6Gh7Jk9Lm2Np4Qr6St8Uv2Wx4Yz"
+            );
+        }
+        other => panic!("expected full notification, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn transaction_subscribe_decodes_accounts_notifications() {
+    let url = start_mock_ws_server(json!({
+        "signature": "7Jk9Lm2Np4Qr6St8Uv2Wx4Yz6Bc8De1Fg3Hj5Km7Np9Qr2St4Uv6Wx8Yz1Bc3De5Fg7Hj9Km2Np4Qr6St8Uv2Wx",
+        "slot": 123458u64,
+        "transactionIndex": 19u64,
+        "transaction": {
+            "meta": {
+                "err": null,
+                "fee": 2005000u64,
+                "preBalances": [10, 20, 30],
+                "postBalances": [11, 21, 31],
+                "status": { "Ok": null }
+            },
+            "transaction": {
+                "accountKeys": [
+                    {
+                        "pubkey": "9Ab3Cd5Ef7Gh9Jk2Lm4Np6Qr8St1Uv3Wx5Yz7bCe9DfG",
+                        "signer": true,
+                        "source": "transaction",
+                        "writable": true
+                    },
+                    {
+                        "pubkey": "2Qr4St6Uv8Wx1Yz3Bc5De7Fg9Hj2Km4Np6Qr8St1Uv3W",
+                        "signer": false,
+                        "source": "lookupTable",
+                        "writable": false
+                    }
+                ],
+                "signatures": [
+                    "7Jk9Lm2Np4Qr6St8Uv2Wx4Yz6Bc8De1Fg3Hj5Km7Np9Qr2St4Uv6Wx8Yz1Bc3De5Fg7Hj9Km2Np4Qr6St8Uv2Wx"
+                ]
+            },
+            "version": 0
+        }
+    }))
+    .await;
+
+    let ws = EnhancedWebsocket::new(&url, Some(30), None).await.unwrap();
+    let (mut stream, _unsub) = ws
+        .transaction_subscribe(subscription_config(TransactionDetails::Accounts))
+        .await
+        .unwrap();
+
+    let event = timeout(Duration::from_secs(2), stream.next())
+        .await
+        .expect("timed out waiting for accounts notification")
+        .expect("stream ended before accounts notification");
+
+    match event {
+        TransactionNotification::Full(entry) => {
+            assert_eq!(entry.slot, 123458);
+            assert_eq!(entry.transaction_index, 19);
+            assert_eq!(
+                entry.signature,
+                "7Jk9Lm2Np4Qr6St8Uv2Wx4Yz6Bc8De1Fg3Hj5Km7Np9Qr2St4Uv6Wx8Yz1Bc3De5Fg7Hj9Km2Np4Qr6St8Uv2Wx"
+            );
+            assert!(matches!(
+                entry.transaction.transaction,
+                solana_transaction_status::EncodedTransaction::Accounts(_)
+            ));
+        }
+        other => panic!("expected full notification carrying accounts payload, got {other:?}"),
+    }
+}


### PR DESCRIPTION
fixes `transactionSubscribe` with `transactionDetails=signatures` causing a decode error because the payload doesn't include a `transaction` field.

does this by making websocket notifications use the same enum-style shape that `TransactionEntry` uses for `getTransactionsForAddress`
