### PR TITLE
Adds initial Admin API support to helius-rust-sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Added
 - `FullTransactionNotification` struct for full-mode `transactionSubscribe` payloads, including `transaction`, `signature`, `slot`, and `transaction_index`
+- Admin API support via `get_project_usage`, including typed project usage models, tests, examples, and docs
 
 ### Changed
 - **Breaking**: `TransactionNotification` changed from a struct to an enum with `Full`, `Signature`, and `Unknown` variants to support all `transactionSubscribe` detail modes. Code that accessed `event.signature` or `event.transaction` directly must now match on the variant first.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -121,6 +121,11 @@ path = "examples/solana/get_latest_blockhash_async.rs"
 name = "send_smart_transaction_with_seeds"
 path = "examples/transactions/send_smart_transaction_with_seeds.rs"
 
+# Admin API examples
+[[example]]
+name = "get_project_usage"
+path = "examples/admin/get_project_usage.rs"
+
 # Wallet API examples
 [[example]]
 name = "get_batch_wallet_identity"

--- a/README.md
+++ b/README.md
@@ -257,6 +257,11 @@ Our SDK is designed to provide a seamless developer experience when building on 
 - [`get_wallet_transfers`](https://www.helius.dev/docs/api-reference/wallet/get-wallet-transfers) - Gets all token transfer activity for a wallet
 - [`get_wallet_funding_source`](https://www.helius.dev/docs/api-reference/wallet/get-wallet-funding-source) - Discovers the original funding source of a wallet
 
+### Admin API
+- `get_project_usage` - Gets billing-period credits, prepaid credits, subscription details, and per-product usage breakdown for a project
+
+Admin API access is feature-gated per project and served from `https://admin-api.helius.xyz/v0`. The API key must belong to the same project as the requested `project_id`.
+
 ### Helius Sender
 - [`create_smart_transaction_with_tip_for_sender`](https://github.com/helius-labs/helius-rust-sdk/blob/47d68afcf644938bc474f609368b214170423bba/src/optimized_transaction.rs#L978-L1007) - Creates an optimized smart transaction with an appended tip transfer instruction for Sender
 - [`determine_tip_lamports`](https://github.com/helius-labs/helius-rust-sdk/blob/47d68afcf644938bc474f609368b214170423bba/src/optimized_transaction.rs#L966-L976) - Determines the tip amount in lamports using the 75th percentile floor or falling back to the minimum required by Sender

--- a/examples/admin/get_project_usage.rs
+++ b/examples/admin/get_project_usage.rs
@@ -1,0 +1,33 @@
+use helius::error::Result;
+use helius::types::Cluster;
+use helius::Helius;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let api_key: &str = "your_api_key";
+    let project_id: &str = "your_project_id";
+
+    let helius: Helius = Helius::new(api_key, Cluster::MainnetBeta).unwrap();
+    let response = helius.get_project_usage(project_id).await;
+
+    match response {
+        Ok(usage) => {
+            println!("Project Usage:");
+            println!("  Credits Used: {}", usage.credits_used);
+            println!("  Credits Remaining: {}", usage.credits_remaining);
+            println!("  Prepaid Credits Used: {}", usage.prepaid_credits_used);
+            println!("  Prepaid Credits Remaining: {}", usage.prepaid_credits_remaining);
+            println!("  Plan: {}", usage.subscription_details.plan);
+            println!(
+                "  Billing Cycle: {} -> {}",
+                usage.subscription_details.billing_cycle.start, usage.subscription_details.billing_cycle.end
+            );
+            println!("  RPC Usage: {}", usage.usage.rpc);
+            println!("  DAS Usage: {}", usage.usage.das);
+            println!("  Webhook Usage: {}", usage.usage.webhook);
+        }
+        Err(e) => println!("Error: {:?}", e),
+    }
+
+    Ok(())
+}

--- a/llms.txt
+++ b/llms.txt
@@ -32,6 +32,7 @@ Use the Helius Rust SDK when you need to:
 - Set up webhooks for on-chain events (sales, transfers, swaps)
 - Stream real-time blockchain data via Enhanced WebSockets
 - Look up wallet identity, balances, transfers, and funding sources
+- Inspect project-level credit usage and billing-period consumption
 - Work with ZK compressed accounts and tokens
 - Stake SOL, unstake, and withdraw via the Helius validator
 - Make RPC calls on Solana's most performant infrastructure
@@ -94,6 +95,8 @@ examples/
 │   └── get_latest_blockhash_async.rs         #   Async blockhash fetch
 ├── transactions/                             # Smart transactions & Helius Sender
 │   └── send_smart_transaction_with_seeds.rs  #   Thread-safe transaction sending
+├── admin/                                    # Admin API
+│   └── get_project_usage.rs                  #   Project credit usage
 ├── wallet/                                   # Wallet API
 │   ├── get_wallet_identity.rs                #   Wallet identity lookup
 │   ├── get_batch_wallet_identity.rs          #   Batch identity lookup
@@ -494,6 +497,17 @@ let transfers = helius.get_wallet_transfers("wallet_address", Some(50), None).aw
 // Original funding source analysis
 let funding = helius.get_wallet_funding_source("wallet_address").await?;
 println!("Funded by: {} with {} SOL", funding.funder, funding.amount);
+```
+
+### Admin API
+
+Inspect billing-period credits, prepaid credits, and per-product usage for a project.
+
+```rust
+let usage = helius.get_project_usage("project_id").await?;
+println!("Credits used: {}", usage.credits_used);
+println!("Credits remaining: {}", usage.credits_remaining);
+println!("RPC usage: {}", usage.usage.rpc);
 ```
 
 ### ZK Compression

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -1,0 +1,73 @@
+use crate::error::Result;
+use crate::types::ProjectUsage;
+use crate::Helius;
+
+use reqwest::{Method, Url};
+
+const ADMIN_API_BASE_URL: &str = "https://admin-api.helius.xyz/";
+
+impl Helius {
+    /// Get the appropriate base URL for Admin API calls.
+    ///
+    /// Uses the config's API endpoint for testing/custom URLs, otherwise uses the
+    /// production Admin API endpoint.
+    fn get_admin_api_base_url(&self) -> String {
+        let api_url = &self.config.endpoints.api;
+        if self.config.custom_url.is_some()
+            || api_url.starts_with("http://localhost")
+            || api_url.starts_with("http://127.0.0.1")
+        {
+            let mut local_url = self.config.endpoints.api.clone();
+            if !local_url.ends_with('/') {
+                local_url.push('/');
+            }
+            local_url
+        } else {
+            ADMIN_API_BASE_URL.to_string()
+        }
+    }
+
+    /// Retrieves current billing-period usage for a project tied to the API key.
+    ///
+    /// Returns the included credit balance, prepaid credit balance, subscription details,
+    /// and a per-product usage breakdown for the given project.
+    ///
+    /// # Arguments
+    /// * `project_id` - The Helius project ID to inspect
+    ///
+    /// # Returns
+    /// A `Result` wrapping a `ProjectUsage` summary for the project
+    ///
+    /// # Errors
+    /// Returns a `HeliusError` if:
+    /// - The API key is missing
+    /// - The project ID is invalid
+    /// - The API key does not have access to the project
+    /// - The API request fails
+    ///
+    /// # Example
+    /// ```ignore
+    /// use helius::Helius;
+    /// use helius::types::Cluster;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let helius = Helius::new("your_api_key", Cluster::MainnetBeta).unwrap();
+    ///     let usage = helius.get_project_usage("your_project_id").await.unwrap();
+    ///     println!("Credits remaining: {}", usage.credits_remaining);
+    /// }
+    /// ```
+    pub async fn get_project_usage(&self, project_id: &str) -> Result<ProjectUsage> {
+        let api_key = self.config.require_api_key("admin project usage")?;
+        let base_url = self.get_admin_api_base_url();
+        let url: String = format!(
+            "{}v0/admin/projects/{}/usage?api-key={}",
+            base_url,
+            project_id,
+            api_key.as_str()
+        );
+        let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
+
+        self.rpc_client.handler.send(Method::GET, parsed_url, None::<&()>).await
+    }
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -81,6 +81,8 @@ impl HeliusBuilder {
     /// - Helius-hosted endpoints
     /// - Webhook operations
     /// - Enhanced transaction parsing
+    /// - Wallet API requests
+    /// - Admin API requests
     ///
     /// Optional for custom RPC endpoints.
     ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ use url::Url;
 #[derive(Clone)]
 pub struct Config {
     /// Optional API key for authentication.
-    /// Required for webhooks, enhanced transactions, and Helius-hosted endpoints.
+    /// Required for webhooks, enhanced transactions, the Wallet API, the Admin API, and other Helius-hosted endpoints.
     pub api_key: Option<ApiKey>,
     /// The target Solana cluster the client will interact with
     pub cluster: Cluster,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod admin;
 pub mod builder;
 pub mod client;
 pub mod config;

--- a/src/types/inner.rs
+++ b/src/types/inner.rs
@@ -2844,6 +2844,61 @@ pub struct FundingSource {
     pub explorer_url: String,
 }
 
+/// Billing cycle dates for an Admin API project usage response.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct AdminBillingCycle {
+    /// Inclusive start date of the current billing cycle in `YYYY-MM-DD` format.
+    pub start: String,
+    /// Exclusive end date of the current billing cycle in `YYYY-MM-DD` format.
+    pub end: String,
+}
+
+/// Subscription metadata returned by the Admin API project usage endpoint.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminSubscriptionDetails {
+    /// Current billing cycle window for the project.
+    pub billing_cycle: AdminBillingCycle,
+    /// Included credit limit for the active plan.
+    pub credits_limit: u64,
+    /// Human-readable plan name.
+    pub plan: String,
+}
+
+/// Per-product credit usage returned by the Admin API project usage endpoint.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct AdminUsageBreakdown {
+    pub api: u64,
+    pub archival: u64,
+    pub das: u64,
+    pub grpc: u64,
+    pub grpc_geyser: u64,
+    pub photon: u64,
+    pub rpc: u64,
+    pub stream: u64,
+    pub webhook: u64,
+    pub websocket: u64,
+}
+
+/// Project-level usage summary returned by the Admin API.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectUsage {
+    /// Remaining included credits for the current billing period.
+    pub credits_remaining: u64,
+    /// Total credits consumed in the current billing period.
+    pub credits_used: u64,
+    /// Remaining prepaid credits.
+    pub prepaid_credits_remaining: u64,
+    /// Prepaid credits consumed in the current billing period.
+    pub prepaid_credits_used: u64,
+    /// Plan and billing cycle details for the project.
+    pub subscription_details: AdminSubscriptionDetails,
+    /// Per-product usage counters for the current billing period.
+    pub usage: AdminUsageBreakdown,
+}
+
 /// Options for the token accounts filter in the `get_wallet_history` endpoint.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -15,11 +15,11 @@ pub use self::inner::*;
 pub use self::options::*;
 pub use self::zk_compression_types::*;
 
-// Re-export wallet types
+// Re-export wallet and admin types
 pub use self::inner::{
-    BalanceChange, BalancesPagination, BalancesResponse, BatchIdentityRequest, FundingSource, HistoryResponse,
-    HistoryTransaction, Identity, Nft, Pagination, TokenAccountsOption, TokenBalance, Transfer, TransferDirection,
-    TransfersResponse,
+    AdminBillingCycle, AdminSubscriptionDetails, AdminUsageBreakdown, BalanceChange, BalancesPagination,
+    BalancesResponse, BatchIdentityRequest, FundingSource, HistoryResponse, HistoryTransaction, Identity, Nft,
+    Pagination, ProjectUsage, TokenAccountsOption, TokenBalance, Transfer, TransferDirection, TransfersResponse,
 };
 
 use crate::error::{HeliusError, Result};

--- a/tests/admin/test_get_project_usage.rs
+++ b/tests/admin/test_get_project_usage.rs
@@ -1,0 +1,98 @@
+use helius::config::Config;
+use helius::error::{HeliusError, Result};
+use helius::rpc_client::RpcClient;
+use helius::types::{
+    AdminBillingCycle, AdminSubscriptionDetails, AdminUsageBreakdown, ApiKey, Cluster, HeliusEndpoints, ProjectUsage,
+};
+use helius::Helius;
+use mockito::Server;
+use reqwest::Client;
+use std::sync::Arc;
+
+fn create_test_helius(url: &str) -> Helius {
+    let config: Arc<Config> = Arc::new(Config {
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
+        cluster: Cluster::MainnetBeta,
+        endpoints: HeliusEndpoints {
+            api: url.to_string(),
+            rpc: url.to_string(),
+        },
+        custom_url: None,
+    });
+
+    let client: Client = Client::new();
+    let rpc_client: Arc<RpcClient> = Arc::new(RpcClient::new(Arc::new(client.clone()), Arc::clone(&config)).unwrap());
+
+    Helius {
+        config,
+        client,
+        rpc_client,
+        async_rpc_client: None,
+        ws_client: None,
+    }
+}
+
+#[tokio::test]
+async fn test_get_project_usage_success() {
+    let mut server: Server = Server::new_with_opts_async(mockito::ServerOpts::default()).await;
+    let url: String = format!("{}/", server.url());
+
+    let mock_response = ProjectUsage {
+        credits_remaining: 999_080,
+        credits_used: 920,
+        prepaid_credits_remaining: 5_000,
+        prepaid_credits_used: 0,
+        subscription_details: AdminSubscriptionDetails {
+            billing_cycle: AdminBillingCycle {
+                start: "2026-04-01".to_string(),
+                end: "2026-05-01".to_string(),
+            },
+            credits_limit: 1_000_000,
+            plan: "Professional".to_string(),
+        },
+        usage: AdminUsageBreakdown {
+            api: 0,
+            archival: 0,
+            das: 200,
+            grpc: 0,
+            grpc_geyser: 0,
+            photon: 0,
+            rpc: 720,
+            stream: 0,
+            webhook: 0,
+            websocket: 0,
+        },
+    };
+
+    server
+        .mock("GET", "/v0/admin/projects/proj-123/usage?api-key=fake_api_key")
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(serde_json::to_string(&mock_response).unwrap())
+        .create();
+
+    let helius = create_test_helius(&url);
+    let response: Result<ProjectUsage> = helius.get_project_usage("proj-123").await;
+
+    assert!(response.is_ok(), "The API call failed: {:?}", response.err());
+
+    let usage: ProjectUsage = response.unwrap();
+    assert_eq!(usage.credits_remaining, 999_080);
+    assert_eq!(usage.credits_used, 920);
+    assert_eq!(usage.subscription_details.plan, "Professional");
+    assert_eq!(usage.subscription_details.billing_cycle.start, "2026-04-01");
+    assert_eq!(usage.usage.rpc, 720);
+    assert_eq!(usage.usage.das, 200);
+}
+
+#[tokio::test]
+async fn test_get_project_usage_requires_api_key() {
+    let helius: Helius = Helius::new_with_url("http://localhost:8899").unwrap();
+
+    let response: Result<ProjectUsage> = helius.get_project_usage("proj-123").await;
+    assert!(
+        matches!(response, Err(HeliusError::InvalidInput(ref text)) if text.contains("admin project usage")),
+        "Expected missing-api-key error, got: {:?}",
+        response
+    );
+}

--- a/tests/test_error_handling.rs
+++ b/tests/test_error_handling.rs
@@ -224,6 +224,85 @@ async fn test_wallet_internal_error_500() {
 }
 
 // ---------------------------------------------------------------------------
+// Admin endpoint error tests (GET /v0/admin/projects/.../usage)
+// ---------------------------------------------------------------------------
+
+async fn admin_project_usage_error_test(status: u16, body: &str) -> HeliusError {
+    let mut server: Server = Server::new_with_opts_async(mockito::ServerOpts::default()).await;
+    let url: String = format!("{}/", server.url());
+
+    server
+        .mock("GET", "/v0/admin/projects/proj-123/usage?api-key=fake_api_key")
+        .with_status(status.into())
+        .with_header("Content-Type", "application/json")
+        .with_body(body)
+        .create();
+
+    let helius = create_test_helius(&url);
+    helius.get_project_usage("proj-123").await.unwrap_err()
+}
+
+#[tokio::test]
+async fn test_admin_bad_request_400() {
+    let err = admin_project_usage_error_test(400, r#"{"error":"Invalid project ID"}"#).await;
+    assert!(
+        matches!(err, HeliusError::BadRequest { ref text, .. } if text.contains("Invalid project ID")),
+        "Expected BadRequest, got: {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn test_admin_unauthorized_401() {
+    let err = admin_project_usage_error_test(401, r#"{"error":"Invalid API key"}"#).await;
+    assert!(
+        matches!(err, HeliusError::Unauthorized { .. }),
+        "Expected Unauthorized, got: {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn test_admin_forbidden_403() {
+    let err = admin_project_usage_error_test(403, r#"{"error":"Admin API not enabled"}"#).await;
+    assert!(
+        matches!(err, HeliusError::Unauthorized { .. }),
+        "Expected Unauthorized (403 maps to Unauthorized), got: {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn test_admin_not_found_404() {
+    let err = admin_project_usage_error_test(404, r#"{"error":"Project not found"}"#).await;
+    assert!(
+        matches!(err, HeliusError::NotFound { ref text } if text.contains("Project not found")),
+        "Expected NotFound, got: {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn test_admin_rate_limit_429() {
+    let err = admin_project_usage_error_test(429, r#"{"error":"Too many requests"}"#).await;
+    assert!(
+        matches!(err, HeliusError::RateLimitExceeded { .. }),
+        "Expected RateLimitExceeded, got: {:?}",
+        err
+    );
+}
+
+#[tokio::test]
+async fn test_admin_internal_error_500() {
+    let err = admin_project_usage_error_test(500, r#"{"error":"Internal Server Error"}"#).await;
+    assert!(
+        matches!(err, HeliusError::InternalError { .. }),
+        "Expected InternalError, got: {:?}",
+        err
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Enhanced transactions endpoint error tests (POST /v0/transactions?...)
 // ---------------------------------------------------------------------------
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -29,6 +29,9 @@ mod wallet {
     mod test_get_wallet_identity;
     mod test_get_wallet_transfers;
 }
+mod admin {
+    mod test_get_project_usage;
+}
 mod webhook {
     mod test_create_webhook;
     mod test_edit_webhook;


### PR DESCRIPTION
Adds initial Admin API support to helius-rust-sdk

This PR introduces `Helius::get_project_usage(project_id)` for fetching project usage and credit data from the Admin API. It also adds the supporting response types, test coverage, example usage, and documentation updates so the new endpoint is ready to use.

Included:
- `Helius::get_project_usage(project_id)`
- Admin API response models
- Tests and example
- README, `llms.txt`, and changelog updates