### PR TITLE
Add getTransfersByAddress RPC wrapper

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,10 @@ path = "examples/helius/get_priority_fee_estimate.rs"
 name = "get_token_accounts_by_owner_v2"
 path = "examples/helius/get_token_accounts_by_owner_v2.rs"
 
+[[example]]
+name = "get_transfers_by_address"
+path = "examples/helius/get_transfers_by_address.rs"
+
 # Solana RPC examples
 [[example]]
 name = "get_latest_blockhash"

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Our SDK is designed to provide a seamless developer experience when building on 
 ### RPC Methods
 - [`get_priority_fee_estimate`](https://www.helius.dev/docs/api-reference/priority-fee/getpriorityfeeestimate#getpriorityfeeestimate) - Gets an estimate of the priority fees required for a transaction to be processed more quickly
 - [`get_transactions_for_address`](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress) - Gets transaction history for a specific address with advanced filtering, sorting, and pagination. Optionally include transactions from associated token accounts
-- `get_transfers_by_address` - Gets token and native SOL transfers for a specific address with counterparty, mint, direction, amount, slot, block time, status, sorting, and cursor pagination filters
+- [`get_transfers_by_address`](https://www.helius.dev/docs/rpc/gettransfersbyaddress) - Gets token and native SOL transfers for a specific address with counterparty, mint, direction, amount, slot, block time, sorting, and cursor pagination filters
 
 ### Helper Methods
 - [`deserialize_str_to_number`](https://github.com/helius-labs/helius-rust-sdk/blob/dev/src/utils/deserialize_str_to_number.rs) - Deserializes a `String` to a `Number`

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Our SDK is designed to provide a seamless developer experience when building on 
 ### RPC Methods
 - [`get_priority_fee_estimate`](https://www.helius.dev/docs/api-reference/priority-fee/getpriorityfeeestimate#getpriorityfeeestimate) - Gets an estimate of the priority fees required for a transaction to be processed more quickly
 - [`get_transactions_for_address`](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress) - Gets transaction history for a specific address with advanced filtering, sorting, and pagination. Optionally include transactions from associated token accounts
-- [`get_transfers_by_address`](https://www.helius.dev/docs/rpc/gettransfersbyaddress) - Gets token and native SOL transfers for a specific address with counterparty, mint, direction, amount, slot, block time, sorting, and cursor pagination filters
+- [`get_transfers_by_address`](https://www.helius.dev/docs/api-reference/rpc/http/gettransfersbyaddress) - Gets token and native SOL transfers for a specific address with counterparty, mint, direction, amount, slot, block time, sorting, and cursor pagination filters
 
 ### Helper Methods
 - [`deserialize_str_to_number`](https://github.com/helius-labs/helius-rust-sdk/blob/dev/src/utils/deserialize_str_to_number.rs) - Deserializes a `String` to a `Number`

--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Our SDK is designed to provide a seamless developer experience when building on 
 ### RPC Methods
 - [`get_priority_fee_estimate`](https://www.helius.dev/docs/api-reference/priority-fee/getpriorityfeeestimate#getpriorityfeeestimate) - Gets an estimate of the priority fees required for a transaction to be processed more quickly
 - [`get_transactions_for_address`](https://www.helius.dev/docs/api-reference/rpc/http/gettransactionsforaddress) - Gets transaction history for a specific address with advanced filtering, sorting, and pagination. Optionally include transactions from associated token accounts
+- `get_transfers_by_address` - Gets token and native SOL transfers for a specific address with counterparty, mint, direction, amount, slot, block time, status, sorting, and cursor pagination filters
 
 ### Helper Methods
 - [`deserialize_str_to_number`](https://github.com/helius-labs/helius-rust-sdk/blob/dev/src/utils/deserialize_str_to_number.rs) - Deserializes a `String` to a `Number`

--- a/examples/helius/get_transfers_by_address.rs
+++ b/examples/helius/get_transfers_by_address.rs
@@ -1,7 +1,7 @@
 use helius::error::Result;
 use helius::types::{
     Cluster, GetTransfersByAddressConfig, GetTransfersByAddressDirection, GetTransfersByAddressFilters,
-    GetTransfersByAddressSolMode, SortOrder, TransferBlockTimeFilter, TransferStatusFilter,
+    GetTransfersByAddressSolMode, SortOrder, TransferBlockTimeFilter,
 };
 use helius::Helius;
 
@@ -21,7 +21,6 @@ async fn main() -> Result<()> {
                 gte: Some(1_704_067_200),
                 ..Default::default()
             }),
-            status: Some(TransferStatusFilter::Succeeded),
             ..Default::default()
         }),
         ..Default::default()

--- a/examples/helius/get_transfers_by_address.rs
+++ b/examples/helius/get_transfers_by_address.rs
@@ -1,0 +1,48 @@
+use helius::error::Result;
+use helius::types::{
+    Cluster, GetTransfersByAddressConfig, GetTransfersByAddressDirection, GetTransfersByAddressFilters,
+    GetTransfersByAddressSolMode, SortOrder, TransferBlockTimeFilter, TransferStatusFilter,
+};
+use helius::Helius;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let api_key = "your_api_key";
+    let helius = Helius::new(api_key, Cluster::MainnetBeta)?;
+
+    let address = "wallet_address";
+    let config = GetTransfersByAddressConfig {
+        limit: Some(10),
+        direction: Some(GetTransfersByAddressDirection::Any),
+        sol_mode: Some(GetTransfersByAddressSolMode::Merged),
+        sort_order: Some(SortOrder::Desc),
+        filters: Some(GetTransfersByAddressFilters {
+            block_time: Some(TransferBlockTimeFilter {
+                gte: Some(1_704_067_200),
+                ..Default::default()
+            }),
+            status: Some(TransferStatusFilter::Succeeded),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    let result = helius
+        .rpc()
+        .get_transfers_by_address(address.to_string(), Some(config))
+        .await?;
+
+    println!("Fetched {} transfers", result.data.len());
+    for transfer in &result.data {
+        println!(
+            "{}: {} {} from {:?} to {:?}",
+            transfer.signature, transfer.ui_amount, transfer.mint, transfer.from_user_account, transfer.to_user_account
+        );
+    }
+
+    if let Some(token) = result.pagination_token {
+        println!("Pagination token for next page: {}", token);
+    }
+
+    Ok(())
+}

--- a/llms.txt
+++ b/llms.txt
@@ -379,8 +379,7 @@ Fetch token and native SOL transfers for an address. This is a thin Helius-only 
 
 ```rust
 use helius::types::{
-    GetTransfersByAddressConfig, GetTransfersByAddressDirection, GetTransfersByAddressFilters,
-    TransferStatusFilter,
+    GetTransfersByAddressConfig, GetTransfersByAddressDirection,
 };
 
 let transfers = helius.rpc().get_transfers_by_address(
@@ -388,10 +387,6 @@ let transfers = helius.rpc().get_transfers_by_address(
     Some(GetTransfersByAddressConfig {
         limit: Some(100),
         direction: Some(GetTransfersByAddressDirection::Any),
-        filters: Some(GetTransfersByAddressFilters {
-            status: Some(TransferStatusFilter::Succeeded),
-            ..Default::default()
-        }),
         ..Default::default()
     }),
 ).await?;

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 ---
 url: https://github.com/helius-labs/helius-rust-sdk
-last_updated: 2026-03-20
+last_updated: 2026-05-05
 ---
 
 # Helius Rust SDK

--- a/llms.txt
+++ b/llms.txt
@@ -88,7 +88,8 @@ examples/
 │   ├── async_config_based_creation.rs        #   HeliusBuilder usage
 │   ├── get_priority_fee_estimate.rs          #   Priority fee estimation
 │   ├── get_program_accounts_v2.rs            #   RPC V2: paginated program accounts
-│   └── get_token_accounts_by_owner_v2.rs     #   RPC V2: paginated token accounts
+│   ├── get_token_accounts_by_owner_v2.rs     #   RPC V2: paginated token accounts
+│   └── get_transfers_by_address.rs           #   Address transfer history
 ├── solana/                                   # Standard Solana RPC
 │   ├── get_latest_blockhash.rs               #   Sync blockhash fetch
 │   └── get_latest_blockhash_async.rs         #   Async blockhash fetch
@@ -370,6 +371,40 @@ let all_token_accounts = helius.rpc().get_all_token_accounts_by_owner(
     TokenAccountsOwnerFilter::Mint("mint_address".to_string()),
     GetTokenAccountsByOwnerV2Config::default(),
 ).await?;
+```
+
+#### getTransfersByAddress
+
+Fetch token and native SOL transfers for an address. This is a thin Helius-only RPC wrapper with cursor pagination.
+
+```rust
+use helius::types::{
+    GetTransfersByAddressConfig, GetTransfersByAddressDirection, GetTransfersByAddressFilters,
+    TransferStatusFilter,
+};
+
+let transfers = helius.rpc().get_transfers_by_address(
+    "wallet_address".to_string(),
+    Some(GetTransfersByAddressConfig {
+        limit: Some(100),
+        direction: Some(GetTransfersByAddressDirection::Any),
+        filters: Some(GetTransfersByAddressFilters {
+            status: Some(TransferStatusFilter::Succeeded),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }),
+).await?;
+
+if let Some(token) = transfers.pagination_token {
+    let next_page = helius.rpc().get_transfers_by_address(
+        "wallet_address".to_string(),
+        Some(GetTransfersByAddressConfig {
+            pagination_token: Some(token),
+            ..Default::default()
+        }),
+    ).await?;
+}
 ```
 
 ### Enhanced Transactions

--- a/src/rpc_client.rs
+++ b/src/rpc_client.rs
@@ -29,7 +29,8 @@ use crate::types::{
     GetPriorityFeeEstimateRequest, GetPriorityFeeEstimateResponse, GetProgramAccountsV2Config,
     GetProgramAccountsV2Request, GetProgramAccountsV2Response, GetTokenAccounts, GetTokenAccountsByOwnerV2Config,
     GetTokenAccountsByOwnerV2Request, GetTokenAccountsByOwnerV2Response, GetTransactionsForAddressOptions,
-    GetTransactionsForAddressRequest, GetTransactionsForAddressResponse, GpaAccount, SearchAssets, TokenAccountRecord,
+    GetTransactionsForAddressRequest, GetTransactionsForAddressResponse, GetTransfersByAddressConfig,
+    GetTransfersByAddressRequest, GetTransfersByAddressResponse, GpaAccount, SearchAssets, TokenAccountRecord,
     TokenAccountsList, TokenAccountsOwnerFilter, TransactionSignatureList,
 };
 
@@ -447,5 +448,26 @@ impl RpcClient {
     ) -> Result<GetTransactionsForAddressResponse> {
         let params: GetTransactionsForAddressRequest = (address, options);
         self.post_rpc_request("getTransactionsForAddress", params).await
+    }
+
+    /// Gets token and native SOL transfers for a specific address.
+    ///
+    /// This is a thin wrapper around the Helius-only `getTransfersByAddress`
+    /// JSON-RPC method. The config is optional; when omitted, the request params
+    /// serialize as `[address]`.
+    ///
+    /// # Arguments
+    /// * `address` - The base58 encoded public key of the account
+    /// * `config` - Optional filters, pagination, commitment, and sorting config
+    ///
+    /// # Returns
+    /// A `Result` containing transfer data and an optional pagination token.
+    pub async fn get_transfers_by_address(
+        &self,
+        address: String,
+        config: Option<GetTransfersByAddressConfig>,
+    ) -> Result<GetTransfersByAddressResponse> {
+        let params: GetTransfersByAddressRequest = GetTransfersByAddressRequest::new(address, config);
+        self.post_rpc_request("getTransfersByAddress", params).await
     }
 }

--- a/src/types/inner.rs
+++ b/src/types/inner.rs
@@ -2652,17 +2652,6 @@ pub struct GetTransfersByAddressFilters {
     pub slot: Option<TransferSlotFilter>,
 }
 
-/// Commitment level accepted by `getTransfersByAddress`.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
-#[serde(rename_all = "lowercase")]
-pub enum GetTransfersByAddressCommitment {
-    /// Finalized transfer data
-    #[default]
-    Finalized,
-    /// Confirmed transfer data
-    Confirmed,
-}
-
 /// Request config for the `getTransfersByAddress` RPC method.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
@@ -2690,7 +2679,7 @@ pub struct GetTransfersByAddressConfig {
     pub pagination_token: Option<String>,
     /// Commitment level for the query
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub commitment: Option<GetTransfersByAddressCommitment>,
+    pub commitment: Option<CommitmentLevel>,
     /// Sort direction
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sort_order: Option<SortOrder>,

--- a/src/types/inner.rs
+++ b/src/types/inner.rs
@@ -4,6 +4,7 @@ use super::{
     TransactionStatus, TransactionType, UiTransactionEncoding, WebhookType,
 };
 use crate::types::{DisplayOptions, Encoding, GetAssetOptions, GpaFilter, TokenAccountsOwnerFilter};
+use serde::ser::SerializeTuple;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::Arc;
@@ -2575,6 +2576,232 @@ pub struct GetTransactionsForAddressResponse {
 
 /// Request type for `getTransactionsForAddress`: a tuple of `(address, options)`.
 pub type GetTransactionsForAddressRequest = (String, GetTransactionsForAddressOptions);
+
+/// Direction of transfers relative to the queried address.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum GetTransfersByAddressDirection {
+    /// Incoming transfers only
+    In,
+    /// Outgoing transfers only
+    Out,
+    /// Incoming and outgoing transfers
+    #[default]
+    Any,
+}
+
+/// Native SOL grouping mode for `getTransfersByAddress`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum GetTransfersByAddressSolMode {
+    /// Merge native SOL and WSOL transfer activity
+    #[default]
+    Merged,
+    /// Return native SOL and WSOL transfer activity separately
+    Separate,
+}
+
+/// Filter transfers by raw amount.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct TransferAmountFilter {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gt: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gte: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lt: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lte: Option<f64>,
+}
+
+/// Filter transfers by block timestamp (Unix seconds).
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct TransferBlockTimeFilter {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gt: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gte: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lt: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lte: Option<i64>,
+}
+
+/// Filter transfers by slot range.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct TransferSlotFilter {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gt: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gte: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lt: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub lte: Option<u64>,
+}
+
+/// Filter transfers by execution status.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum TransferStatusFilter {
+    /// Successful transfers only
+    Succeeded,
+    /// Failed transfers only
+    Failed,
+    /// Successful and failed transfers
+    #[default]
+    Any,
+}
+
+/// Combined filters for `getTransfersByAddress`.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GetTransfersByAddressFilters {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub amount: Option<TransferAmountFilter>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub block_time: Option<TransferBlockTimeFilter>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slot: Option<TransferSlotFilter>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<TransferStatusFilter>,
+}
+
+/// Commitment level accepted by `getTransfersByAddress`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum GetTransfersByAddressCommitment {
+    /// Finalized transfer data
+    #[default]
+    Finalized,
+    /// Confirmed transfer data
+    Confirmed,
+}
+
+/// Request config for the `getTransfersByAddress` RPC method.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GetTransfersByAddressConfig {
+    /// Counterparty address to filter by
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub with: Option<String>,
+    /// Transfer direction relative to the queried address
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub direction: Option<GetTransfersByAddressDirection>,
+    /// Token mint address to filter by
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mint: Option<String>,
+    /// Native SOL grouping mode
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sol_mode: Option<GetTransfersByAddressSolMode>,
+    /// Combined filters for amount, block time, slot, and status
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filters: Option<GetTransfersByAddressFilters>,
+    /// Maximum number of transfers per page. The server accepts 1-100.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    /// Cursor from a previous response for fetching the next page
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pagination_token: Option<String>,
+    /// Commitment level for the query
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commitment: Option<GetTransfersByAddressCommitment>,
+    /// Sort direction
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sort_order: Option<SortOrder>,
+}
+
+/// Request parameters for `getTransfersByAddress`.
+///
+/// Serializes to `[address]` when `config` is `None`, and `[address, config]` when
+/// a config is provided.
+#[derive(Debug, Clone, Default)]
+pub struct GetTransfersByAddressRequest {
+    pub address: String,
+    pub config: Option<GetTransfersByAddressConfig>,
+}
+
+impl GetTransfersByAddressRequest {
+    pub fn new(address: String, config: Option<GetTransfersByAddressConfig>) -> Self {
+        Self { address, config }
+    }
+}
+
+impl Serialize for GetTransfersByAddressRequest {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let len = if self.config.is_some() { 2 } else { 1 };
+        let mut tuple = serializer.serialize_tuple(len)?;
+        tuple.serialize_element(&self.address)?;
+        if let Some(config) = &self.config {
+            tuple.serialize_element(config)?;
+        }
+        tuple.end()
+    }
+}
+
+/// Transfer event type returned by `getTransfersByAddress`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub enum GetTransfersByAddressTransferType {
+    Transfer,
+    TransferFee,
+    Mint,
+    Burn,
+    Wrap,
+    Unwrap,
+    ChangeAccountOwner,
+    WithdrawWithheldFee,
+}
+
+/// Confirmation status returned by `getTransfersByAddress`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum TransferConfirmationStatus {
+    Finalized,
+    Confirmed,
+}
+
+/// A transfer returned by `getTransfersByAddress`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct GetTransfersByAddressTransfer {
+    pub signature: String,
+    pub slot: u64,
+    pub block_time: i64,
+    #[serde(rename = "type")]
+    pub transfer_type: GetTransfersByAddressTransferType,
+    pub from_user_account: Option<String>,
+    pub to_user_account: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub from_token_account: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub to_token_account: Option<String>,
+    pub mint: String,
+    pub amount: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fee_amount: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fee_account: Option<String>,
+    pub decimals: u8,
+    pub ui_amount: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fee_ui_amount: Option<String>,
+    pub confirmation_status: TransferConfirmationStatus,
+    pub transaction_idx: u64,
+    pub instruction_idx: u64,
+    pub inner_instruction_idx: u64,
+}
+
+/// Response from `getTransfersByAddress`.
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct GetTransfersByAddressResponse {
+    pub data: Vec<GetTransfersByAddressTransfer>,
+    pub pagination_token: Option<String>,
+}
 
 /// Identity information for a known wallet address (exchanges, protocols, etc.)
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]

--- a/src/types/inner.rs
+++ b/src/types/inner.rs
@@ -2605,13 +2605,13 @@ pub enum GetTransfersByAddressSolMode {
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct TransferAmountFilter {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub gt: Option<f64>,
+    pub gt: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub gte: Option<f64>,
+    pub gte: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub lt: Option<f64>,
+    pub lt: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub lte: Option<f64>,
+    pub lte: Option<u64>,
 }
 
 /// Filter transfers by block timestamp (Unix seconds).
@@ -2640,19 +2640,6 @@ pub struct TransferSlotFilter {
     pub lte: Option<u64>,
 }
 
-/// Filter transfers by execution status.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
-#[serde(rename_all = "lowercase")]
-pub enum TransferStatusFilter {
-    /// Successful transfers only
-    Succeeded,
-    /// Failed transfers only
-    Failed,
-    /// Successful and failed transfers
-    #[default]
-    Any,
-}
-
 /// Combined filters for `getTransfersByAddress`.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 #[serde(rename_all = "camelCase")]
@@ -2663,8 +2650,6 @@ pub struct GetTransfersByAddressFilters {
     pub block_time: Option<TransferBlockTimeFilter>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub slot: Option<TransferSlotFilter>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<TransferStatusFilter>,
 }
 
 /// Commitment level accepted by `getTransfersByAddress`.
@@ -2694,7 +2679,7 @@ pub struct GetTransfersByAddressConfig {
     /// Native SOL grouping mode
     #[serde(skip_serializing_if = "Option::is_none")]
     pub sol_mode: Option<GetTransfersByAddressSolMode>,
-    /// Combined filters for amount, block time, slot, and status
+    /// Combined filters for amount, block time, and slot
     #[serde(skip_serializing_if = "Option::is_none")]
     pub filters: Option<GetTransfersByAddressFilters>,
     /// Maximum number of transfers per page. The server accepts 1-100.
@@ -2747,12 +2732,11 @@ impl Serialize for GetTransfersByAddressRequest {
 #[serde(rename_all = "camelCase")]
 pub enum GetTransfersByAddressTransferType {
     Transfer,
-    TransferFee,
     Mint,
     Burn,
     Wrap,
     Unwrap,
-    ChangeAccountOwner,
+    ChangeOwner,
     WithdrawWithheldFee,
 }
 
@@ -2783,8 +2767,6 @@ pub struct GetTransfersByAddressTransfer {
     pub amount: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fee_amount: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub fee_account: Option<String>,
     pub decimals: u8,
     pub ui_amount: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/tests/rpc/test_get_transfers_by_address.rs
+++ b/tests/rpc/test_get_transfers_by_address.rs
@@ -43,7 +43,7 @@ fn test_get_transfers_by_address_request_serialization() {
         sol_mode: Some(GetTransfersByAddressSolMode::Separate),
         filters: Some(GetTransfersByAddressFilters {
             amount: Some(TransferAmountFilter {
-                gte: Some(1.0),
+                gte: Some(1),
                 ..Default::default()
             }),
             block_time: Some(TransferBlockTimeFilter {
@@ -54,7 +54,6 @@ fn test_get_transfers_by_address_request_serialization() {
                 lte: Some(250_000_000),
                 ..Default::default()
             }),
-            status: Some(TransferStatusFilter::Succeeded),
         }),
         limit: Some(25),
         pagination_token: Some("250000000:3".to_string()),
@@ -82,10 +81,9 @@ fn test_get_transfers_by_address_request_serialization() {
                     "mint": "So11111111111111111111111111111111111111112",
                     "solMode": "separate",
                     "filters": {
-                        "amount": { "gte": 1.0 },
+                        "amount": { "gte": 1 },
                         "blockTime": { "gt": 1701234567 },
-                        "slot": { "lte": 250000000 },
-                        "status": "succeeded"
+                        "slot": { "lte": 250000000 }
                     },
                     "limit": 25,
                     "paginationToken": "250000000:3",
@@ -148,13 +146,12 @@ async fn test_get_transfers_by_address_success() {
                     "signature": "4m7xBEauJ3PK6SWCZ1PGjBvj8vDdWG3KpwATGy1ARAXFSDwt8GFXM7W5Ncn16wmqokgpiKRLuS83KUxyZyv2sUYv",
                     "slot": 250000001,
                     "blockTime": 1701234600,
-                    "type": "transferFee",
+                    "type": "transfer",
                     "fromUserAccount": null,
                     "toUserAccount": "FeeCollector",
                     "mint": "So11111111111111111111111111111111111111111",
                     "amount": "5000",
                     "feeAmount": "5000",
-                    "feeAccount": "FeeAccount",
                     "decimals": 9,
                     "uiAmount": "0.000005",
                     "feeUiAmount": "0.000005",
@@ -204,10 +201,7 @@ async fn test_get_transfers_by_address_success() {
     assert_eq!(token_transfer.to_token_account, Some("ToTokenAccount".to_string()));
 
     let sol_transfer = &result.data[1];
-    assert_eq!(
-        sol_transfer.transfer_type,
-        GetTransfersByAddressTransferType::TransferFee
-    );
+    assert_eq!(sol_transfer.transfer_type, GetTransfersByAddressTransferType::Transfer);
     assert_eq!(sol_transfer.mint, "So11111111111111111111111111111111111111111");
     assert!(sol_transfer.from_token_account.is_none());
     assert!(sol_transfer.to_token_account.is_none());

--- a/tests/rpc/test_get_transfers_by_address.rs
+++ b/tests/rpc/test_get_transfers_by_address.rs
@@ -10,6 +10,7 @@ use helius::types::*;
 use mockito::{self, Server};
 use reqwest::Client;
 use serde_json::json;
+use solana_commitment_config::CommitmentLevel;
 
 fn test_helius(url: &str) -> Helius {
     let config = Arc::new(Config {
@@ -57,7 +58,7 @@ fn test_get_transfers_by_address_request_serialization() {
         }),
         limit: Some(25),
         pagination_token: Some("250000000:3".to_string()),
-        commitment: Some(GetTransfersByAddressCommitment::Confirmed),
+        commitment: Some(CommitmentLevel::Confirmed),
         sort_order: Some(SortOrder::Asc),
     };
 

--- a/tests/rpc/test_get_transfers_by_address.rs
+++ b/tests/rpc/test_get_transfers_by_address.rs
@@ -1,0 +1,241 @@
+use std::sync::Arc;
+
+use helius::client::Helius;
+use helius::config::Config;
+use helius::error::{HeliusError, Result};
+use helius::rpc_client::RpcClient;
+use helius::types::inner::RpcRequest;
+use helius::types::*;
+
+use mockito::{self, Server};
+use reqwest::Client;
+use serde_json::json;
+
+fn test_helius(url: &str) -> Helius {
+    let config = Arc::new(Config {
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
+        cluster: Cluster::Devnet,
+        endpoints: HeliusEndpoints {
+            api: url.to_string(),
+            rpc: url.to_string(),
+        },
+        custom_url: None,
+    });
+
+    let client = Client::new();
+    let rpc_client = Arc::new(RpcClient::new(Arc::new(client.clone()), Arc::clone(&config)).unwrap());
+
+    Helius {
+        config,
+        client,
+        rpc_client,
+        async_rpc_client: None,
+        ws_client: None,
+    }
+}
+
+#[test]
+fn test_get_transfers_by_address_request_serialization() {
+    let config = GetTransfersByAddressConfig {
+        with: Some("CounterpartyAddress".to_string()),
+        direction: Some(GetTransfersByAddressDirection::Out),
+        mint: Some("So11111111111111111111111111111111111111112".to_string()),
+        sol_mode: Some(GetTransfersByAddressSolMode::Separate),
+        filters: Some(GetTransfersByAddressFilters {
+            amount: Some(TransferAmountFilter {
+                gte: Some(1.0),
+                ..Default::default()
+            }),
+            block_time: Some(TransferBlockTimeFilter {
+                gt: Some(1_701_234_567),
+                ..Default::default()
+            }),
+            slot: Some(TransferSlotFilter {
+                lte: Some(250_000_000),
+                ..Default::default()
+            }),
+            status: Some(TransferStatusFilter::Succeeded),
+        }),
+        limit: Some(25),
+        pagination_token: Some("250000000:3".to_string()),
+        commitment: Some(GetTransfersByAddressCommitment::Confirmed),
+        sort_order: Some(SortOrder::Asc),
+    };
+
+    let request = RpcRequest::new(
+        "getTransfersByAddress".to_string(),
+        GetTransfersByAddressRequest::new("SomeAddress".to_string(), Some(config)),
+    );
+
+    let value = serde_json::to_value(request).unwrap();
+    assert_eq!(
+        value,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "helius-rust-sdk",
+            "method": "getTransfersByAddress",
+            "params": [
+                "SomeAddress",
+                {
+                    "with": "CounterpartyAddress",
+                    "direction": "out",
+                    "mint": "So11111111111111111111111111111111111111112",
+                    "solMode": "separate",
+                    "filters": {
+                        "amount": { "gte": 1.0 },
+                        "blockTime": { "gt": 1701234567 },
+                        "slot": { "lte": 250000000 },
+                        "status": "succeeded"
+                    },
+                    "limit": 25,
+                    "paginationToken": "250000000:3",
+                    "commitment": "confirmed",
+                    "sortOrder": "asc"
+                }
+            ]
+        })
+    );
+}
+
+#[test]
+fn test_get_transfers_by_address_omits_optional_config() {
+    let request = RpcRequest::new(
+        "getTransfersByAddress".to_string(),
+        GetTransfersByAddressRequest::new("SomeAddress".to_string(), None),
+    );
+
+    let value = serde_json::to_value(request).unwrap();
+    assert_eq!(
+        value,
+        json!({
+            "jsonrpc": "2.0",
+            "id": "helius-rust-sdk",
+            "method": "getTransfersByAddress",
+            "params": ["SomeAddress"]
+        })
+    );
+}
+
+#[tokio::test]
+async fn test_get_transfers_by_address_success() {
+    let mut server = Server::new_with_opts_async(mockito::ServerOpts::default()).await;
+    let url = server.url();
+
+    let mock_response = json!({
+        "jsonrpc": "2.0",
+        "id": "helius-rust-sdk",
+        "result": {
+            "data": [
+                {
+                    "signature": "5h6xBEauJ3PK6SWCZ1PGjBvj8vDdWG3KpwATGy1ARAXFSDwt8GFXM7W5Ncn16wmqokgpiKRLuS83KUxyZyv2sUYv",
+                    "slot": 250000000,
+                    "blockTime": 1701234567,
+                    "type": "transfer",
+                    "fromUserAccount": "FromWallet",
+                    "toUserAccount": "ToWallet",
+                    "fromTokenAccount": "FromTokenAccount",
+                    "toTokenAccount": "ToTokenAccount",
+                    "mint": "TokenMint",
+                    "amount": "1000000",
+                    "decimals": 6,
+                    "uiAmount": "1",
+                    "confirmationStatus": "finalized",
+                    "transactionIdx": 2,
+                    "instructionIdx": 3,
+                    "innerInstructionIdx": 0
+                },
+                {
+                    "signature": "4m7xBEauJ3PK6SWCZ1PGjBvj8vDdWG3KpwATGy1ARAXFSDwt8GFXM7W5Ncn16wmqokgpiKRLuS83KUxyZyv2sUYv",
+                    "slot": 250000001,
+                    "blockTime": 1701234600,
+                    "type": "transferFee",
+                    "fromUserAccount": null,
+                    "toUserAccount": "FeeCollector",
+                    "mint": "So11111111111111111111111111111111111111111",
+                    "amount": "5000",
+                    "feeAmount": "5000",
+                    "feeAccount": "FeeAccount",
+                    "decimals": 9,
+                    "uiAmount": "0.000005",
+                    "feeUiAmount": "0.000005",
+                    "confirmationStatus": "confirmed",
+                    "transactionIdx": 4,
+                    "instructionIdx": 1,
+                    "innerInstructionIdx": 0
+                }
+            ],
+            "paginationToken": "250000001:4"
+        }
+    });
+
+    server
+        .mock("POST", "/?api-key=fake_api_key")
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(mock_response.to_string())
+        .create();
+
+    let helius = test_helius(&url);
+    let config = GetTransfersByAddressConfig {
+        limit: Some(2),
+        direction: Some(GetTransfersByAddressDirection::Any),
+        ..Default::default()
+    };
+
+    let response = helius
+        .rpc()
+        .get_transfers_by_address("SomeAddress".to_string(), Some(config))
+        .await;
+
+    assert!(response.is_ok(), "API call failed with error: {:?}", response.err());
+
+    let result = response.unwrap();
+    assert_eq!(result.data.len(), 2);
+    assert_eq!(result.pagination_token, Some("250000001:4".to_string()));
+
+    let token_transfer = &result.data[0];
+    assert_eq!(
+        token_transfer.transfer_type,
+        GetTransfersByAddressTransferType::Transfer
+    );
+    assert_eq!(token_transfer.amount, "1000000");
+    assert_eq!(token_transfer.ui_amount, "1");
+    assert_eq!(token_transfer.from_token_account, Some("FromTokenAccount".to_string()));
+    assert_eq!(token_transfer.to_token_account, Some("ToTokenAccount".to_string()));
+
+    let sol_transfer = &result.data[1];
+    assert_eq!(
+        sol_transfer.transfer_type,
+        GetTransfersByAddressTransferType::TransferFee
+    );
+    assert_eq!(sol_transfer.mint, "So11111111111111111111111111111111111111111");
+    assert!(sol_transfer.from_token_account.is_none());
+    assert!(sol_transfer.to_token_account.is_none());
+    assert_eq!(sol_transfer.fee_amount, Some("5000".to_string()));
+    assert_eq!(sol_transfer.confirmation_status, TransferConfirmationStatus::Confirmed);
+}
+
+#[tokio::test]
+async fn test_get_transfers_by_address_failure() {
+    let mut server = Server::new_with_opts_async(mockito::ServerOpts::default()).await;
+    let url = server.url();
+
+    server
+        .mock("POST", "/?api-key=fake_api_key")
+        .with_status(500)
+        .with_header("content-type", "application/json")
+        .with_body(r#"{"error": "Internal Server Error"}"#)
+        .create();
+
+    let helius = test_helius(&url);
+    let response: Result<GetTransfersByAddressResponse> = helius
+        .rpc()
+        .get_transfers_by_address("SomeAddress".to_string(), None)
+        .await;
+
+    assert!(response.is_err(), "Expected an error but got success");
+    assert!(
+        matches!(response.unwrap_err(), HeliusError::InternalError { .. }),
+        "Expected InternalError"
+    );
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -18,6 +18,7 @@ mod rpc {
     mod test_get_signatures_for_asset;
     mod test_get_token_accounts;
     mod test_get_transactions_for_address;
+    mod test_get_transfers_by_address;
     mod test_search_assets;
 }
 mod wallet {


### PR DESCRIPTION
## Summary
- add a thin getTransfersByAddress RPC wrapper with request/response types
- add focused serialization, success, and error tests
- add an example plus README and llms.txt references
- align transfer filters and response fields with the latest Helius docs

## Verification
- cargo fmt -- --check
- cargo check --example get_transfers_by_address
- cargo test --test tests rpc::test_get_transfers_by_address