### PR TITLE
Add `get_wallet_balance_at` For Historical Token Balances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+- `get_wallet_balance_at` Wallet API method for querying a wallet's balance of a specific token or native SOL at a past timestamp, datetime, or slot
+- `BalanceAtQuery` enum (`Time`, `Datetime`, `Slot`) for selecting the historical point to query, plus `BalanceAtResponse`, `BalanceAtRequested`, and `BalanceAtAsOf` response types
+
 ## [1.1.0] - 2026-04-29
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,10 @@ name = "get_batch_wallet_identity"
 path = "examples/wallet/get_batch_wallet_identity.rs"
 
 [[example]]
+name = "get_wallet_balance_at"
+path = "examples/wallet/get_wallet_balance_at.rs"
+
+[[example]]
 name = "get_wallet_balances"
 path = "examples/wallet/get_wallet_balances.rs"
 

--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Our SDK is designed to provide a seamless developer experience when building on 
 - [`get_wallet_identity`](https://www.helius.dev/docs/api-reference/wallet/get-wallet-identity) - Gets identity information (name, type, category) for a known wallet address
 - [`get_batch_wallet_identity`](https://www.helius.dev/docs/api-reference/wallet/get-batch-wallet-identity) - Gets identity information for multiple wallet addresses in a single request (up to 100)
 - [`get_wallet_balances`](https://www.helius.dev/docs/api-reference/wallet/get-wallet-balances) - Gets token and NFT balances for a wallet, sorted by USD value
+- [`get_wallet_balance_at`](https://www.helius.dev/docs/api-reference/wallet-api/balance-at) - Gets a wallet's balance of a specific token or native SOL at a past timestamp, datetime, or slot
 - [`get_wallet_history`](https://www.helius.dev/docs/api-reference/wallet/get-wallet-history) - Gets parsed transaction history with balance changes for a wallet
 - [`get_wallet_transfers`](https://www.helius.dev/docs/api-reference/wallet/get-wallet-transfers) - Gets all token transfer activity for a wallet
 - [`get_wallet_funding_source`](https://www.helius.dev/docs/api-reference/wallet/get-wallet-funding-source) - Discovers the original funding source of a wallet

--- a/examples/wallet/get_wallet_balance_at.rs
+++ b/examples/wallet/get_wallet_balance_at.rs
@@ -1,0 +1,47 @@
+use helius::error::Result;
+use helius::types::{BalanceAtQuery, BalanceAtResponse, Cluster};
+use helius::Helius;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let api_key: &str = "your_api_key";
+    let cluster: Cluster = Cluster::MainnetBeta;
+
+    let helius: Helius = Helius::new(api_key, cluster).unwrap();
+
+    // Example wallet and the USDC mint
+    let wallet: &str = "5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9";
+    let mint: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+    // Query the balance at a past point in time. Provide exactly one of:
+    //   BalanceAtQuery::Time(unix_seconds)
+    //   BalanceAtQuery::Datetime("2025-01-10 19:20:00".to_string())  // UTC unless a timezone is given
+    //   BalanceAtQuery::Slot(313_000_000)                            // exact and deterministic
+    let response: Result<BalanceAtResponse> = helius
+        .get_wallet_balance_at(wallet, mint, BalanceAtQuery::Time(1736536800))
+        .await;
+
+    match response {
+        Ok(balance) => {
+            println!("Wallet: {}", balance.wallet);
+            println!("Mint: {} (native SOL: {})", balance.mint, balance.is_native);
+            println!(
+                "Balance: {} ({} raw, {} decimals)",
+                balance.balance, balance.balance_raw, balance.decimals
+            );
+
+            match balance.as_of {
+                Some(as_of) => {
+                    println!("Read from transaction {} at slot {}", as_of.signature, as_of.slot);
+                    if let Some(block_time) = as_of.block_time {
+                        println!("Block time: {}", block_time);
+                    }
+                }
+                None => println!("No matching activity at or before the requested point — balance is genuinely 0"),
+            }
+        }
+        Err(e) => println!("Error: {:?}", e),
+    }
+
+    Ok(())
+}

--- a/llms.txt
+++ b/llms.txt
@@ -102,6 +102,7 @@ examples/
 │   ├── get_wallet_identity.rs                #   Wallet identity lookup
 │   ├── get_batch_wallet_identity.rs          #   Batch identity lookup
 │   ├── get_wallet_balances.rs                #   Token & NFT balances
+│   ├── get_wallet_balance_at.rs              #   Historical balance at a point in time
 │   ├── get_wallet_history.rs                 #   Transaction history with deltas
 │   ├── get_wallet_transfers.rs               #   Token transfer activity
 │   └── get_wallet_funding_source.rs          #   Original funding source
@@ -510,6 +511,14 @@ let balances = helius.get_wallet_balances(
     Some(true),  // show_nfts
 ).await?;
 println!("Portfolio: ${}", balances.total_usd_value);
+
+// Historical balance at a past timestamp, datetime, or slot (provide exactly one)
+let balance_at = helius.get_wallet_balance_at(
+    "wallet_address",
+    "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v", // mint (SOL pseudo-mint for native)
+    BalanceAtQuery::Time(1736536800),               // or ::Datetime(s) / ::Slot(n)
+).await?;
+println!("Balance: {} ({} raw)", balance_at.balance, balance_at.balance_raw);
 
 // Transaction history with balance changes
 let history = helius.get_wallet_history(

--- a/src/types/inner.rs
+++ b/src/types/inner.rs
@@ -3042,6 +3042,70 @@ pub struct FundingSource {
     pub explorer_url: String,
 }
 
+/// Point in time at which to read a wallet's historical balance
+///
+/// Exactly one of these must be provided to the balance-at endpoint. Use
+/// [`BalanceAtQuery::Slot`] for exact, deterministic results, since block times
+/// reported by validators can drift by a few seconds.
+#[derive(Debug, Clone, PartialEq)]
+pub enum BalanceAtQuery {
+    /// Unix timestamp in seconds. Returns the balance as of this time.
+    Time(i64),
+    /// Datetime string (e.g. `2025-01-10`, `2025-01-10 19:20:00`, `2025-01-10T19:20:00Z`).
+    /// Interpreted as UTC unless an explicit timezone is included.
+    Datetime(String),
+    /// Slot number. Returns the balance as of this slot. Exact and deterministic.
+    Slot(u64),
+}
+
+/// Echo of the query parameters from the balance-at endpoint
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct BalanceAtRequested {
+    /// Requested time as epoch seconds (also set when `datetime` was used)
+    pub time: Option<i64>,
+    /// Requested slot, when `slot` was used
+    pub slot: Option<u64>,
+    /// The original datetime string, when `datetime` was used
+    pub datetime: Option<String>,
+}
+
+/// The transaction a historical balance was read from
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct BalanceAtAsOf {
+    /// Slot of the transaction
+    pub slot: u64,
+    /// Block time of the transaction in Unix seconds (may be null)
+    pub block_time: Option<i64>,
+    /// Transaction signature
+    pub signature: String,
+}
+
+/// Response from the historical balance (balance-at) endpoint
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct BalanceAtResponse {
+    /// Echo of the queried wallet address
+    pub wallet: String,
+    /// Echo of the queried mint (the SOL pseudo-mint when native)
+    pub mint: String,
+    /// Whether the result is native SOL
+    pub is_native: bool,
+    /// Human-readable amount as a decimal string. Trailing zeros are trimmed.
+    pub balance: String,
+    /// Exact amount in the smallest unit (lamports for SOL), as a string
+    pub balance_raw: String,
+    /// Token decimals (9 for SOL)
+    pub decimals: u8,
+    /// Echo of the query parameters
+    pub requested: BalanceAtRequested,
+    /// The transaction the balance was read from. `None` when the wallet had no
+    /// matching transaction at or before the requested point — the balance is
+    /// genuinely `0`, not an error.
+    pub as_of: Option<BalanceAtAsOf>,
+}
+
 /// Billing cycle dates for an Admin API project usage response.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct AdminBillingCycle {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -17,9 +17,10 @@ pub use self::zk_compression_types::*;
 
 // Re-export wallet and admin types
 pub use self::inner::{
-    AdminBillingCycle, AdminSubscriptionDetails, AdminUsageBreakdown, BalanceChange, BalancesPagination,
-    BalancesResponse, BatchIdentityRequest, FundingSource, HistoryResponse, HistoryTransaction, Identity, Nft,
-    Pagination, ProjectUsage, TokenAccountsOption, TokenBalance, Transfer, TransferDirection, TransfersResponse,
+    AdminBillingCycle, AdminSubscriptionDetails, AdminUsageBreakdown, BalanceAtAsOf, BalanceAtQuery,
+    BalanceAtRequested, BalanceAtResponse, BalanceChange, BalancesPagination, BalancesResponse, BatchIdentityRequest,
+    FundingSource, HistoryResponse, HistoryTransaction, Identity, Nft, Pagination, ProjectUsage, TokenAccountsOption,
+    TokenBalance, Transfer, TransferDirection, TransfersResponse,
 };
 
 use crate::error::{HeliusError, Result};

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -1,6 +1,7 @@
 use crate::error::Result;
 use crate::types::{
-    BalancesResponse, BatchIdentityRequest, FundingSource, HistoryResponse, Identity, TransfersResponse,
+    BalanceAtQuery, BalanceAtResponse, BalancesResponse, BatchIdentityRequest, FundingSource, HistoryResponse,
+    Identity, TransfersResponse,
 };
 use crate::Helius;
 
@@ -413,6 +414,87 @@ impl Helius {
             api_key.as_str()
         );
         let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
+
+        self.rpc_client.handler.send(Method::GET, parsed_url, None::<&()>).await
+    }
+
+    /// Retrieves a wallet's balance of a specific token or native SOL at a past point in time
+    ///
+    /// The balance is read from the wallet's most recent transaction involving the token at or
+    /// before the requested point — its post-transaction balance, which held until the wallet's
+    /// next transaction. This is an exact value, not an estimate.
+    ///
+    /// A wallet with no matching activity at or before the requested point is not an error: the
+    /// response has `balance: "0"` and `as_of: None`.
+    ///
+    /// # Arguments
+    /// * `wallet` - The Solana wallet address (base58 encoded)
+    /// * `mint` - Token mint address. For native SOL, use `So11111111111111111111111111111111111111111`
+    /// * `query` - The point in time to query: a [`BalanceAtQuery::Time`] (Unix seconds),
+    ///   [`BalanceAtQuery::Datetime`] string (interpreted as UTC unless a timezone is included),
+    ///   or [`BalanceAtQuery::Slot`] (exact and deterministic)
+    ///
+    /// # Returns
+    /// A `Result` wrapping a `BalanceAtResponse` with the historical balance. `balance` and
+    /// `balance_raw` are strings to avoid precision loss on large values.
+    ///
+    /// # Errors
+    /// Returns a `HeliusError` if:
+    /// - The API key is missing
+    /// - The wallet address or mint is invalid
+    /// - The datetime string is unparseable
+    /// - The API request fails
+    ///
+    /// # Example
+    /// ```ignore
+    /// use helius::Helius;
+    /// use helius::types::{BalanceAtQuery, Cluster};
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let helius = Helius::new("your_api_key", Cluster::MainnetBeta).unwrap();
+    ///     let balance = helius
+    ///         .get_wallet_balance_at(
+    ///             "GQUtvPx89ZNCwmvQqFmH59bJcU8fW8siETpaxod7Aydz",
+    ///             "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+    ///             BalanceAtQuery::Time(1736536800),
+    ///         )
+    ///         .await
+    ///         .unwrap();
+    ///     println!("Balance: {} ({} raw)", balance.balance, balance.balance_raw);
+    /// }
+    /// ```
+    pub async fn get_wallet_balance_at(
+        &self,
+        wallet: &str,
+        mint: &str,
+        query: BalanceAtQuery,
+    ) -> Result<BalanceAtResponse> {
+        let api_key = self.config.require_api_key("wallet balance at")?;
+        let base_url = self.get_wallet_api_base_url();
+        let url: String = format!(
+            "{}v1/wallet/{}/balance-at?api-key={}&mint={}",
+            base_url,
+            wallet,
+            api_key.as_str(),
+            mint
+        );
+
+        let mut parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
+
+        // Append the time selector with form-encoding so datetime values containing
+        // spaces or `+` timezone offsets survive transport intact.
+        match query {
+            BalanceAtQuery::Time(time) => {
+                parsed_url.query_pairs_mut().append_pair("time", &time.to_string());
+            }
+            BalanceAtQuery::Datetime(datetime) => {
+                parsed_url.query_pairs_mut().append_pair("datetime", &datetime);
+            }
+            BalanceAtQuery::Slot(slot) => {
+                parsed_url.query_pairs_mut().append_pair("slot", &slot.to_string());
+            }
+        }
 
         self.rpc_client.handler.send(Method::GET, parsed_url, None::<&()>).await
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -24,6 +24,7 @@ mod rpc {
 }
 mod wallet {
     mod test_get_batch_wallet_identity;
+    mod test_get_wallet_balance_at;
     mod test_get_wallet_balances;
     mod test_get_wallet_funding_source;
     mod test_get_wallet_history;

--- a/tests/wallet/test_get_wallet_balance_at.rs
+++ b/tests/wallet/test_get_wallet_balance_at.rs
@@ -1,0 +1,190 @@
+use helius::config::Config;
+use helius::error::Result;
+use helius::rpc_client::RpcClient;
+use helius::types::{
+    ApiKey, BalanceAtAsOf, BalanceAtQuery, BalanceAtRequested, BalanceAtResponse, Cluster, HeliusEndpoints,
+};
+use helius::Helius;
+use mockito::Server;
+use reqwest::Client;
+use std::sync::Arc;
+
+fn make_helius(url: &str) -> Helius {
+    let config: Arc<Config> = Arc::new(Config {
+        api_key: Some(ApiKey::new("fake_api_key").unwrap()),
+        cluster: Cluster::MainnetBeta,
+        endpoints: HeliusEndpoints {
+            api: url.to_string(),
+            rpc: url.to_string(),
+        },
+        custom_url: None,
+    });
+
+    let client: Client = Client::new();
+    let rpc_client: Arc<RpcClient> = Arc::new(RpcClient::new(Arc::new(client.clone()), Arc::clone(&config)).unwrap());
+    Helius {
+        config,
+        client,
+        rpc_client,
+        async_rpc_client: None,
+        ws_client: None,
+    }
+}
+
+#[tokio::test]
+async fn test_get_wallet_balance_at_with_time() {
+    let mut server: Server = Server::new_with_opts_async(mockito::ServerOpts::default()).await;
+    let url: String = format!("{}/", server.url());
+
+    let mock_response: BalanceAtResponse = BalanceAtResponse {
+        wallet: "5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9".to_string(),
+        mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+        is_native: false,
+        balance: "284961463.392936".to_string(),
+        balance_raw: "284961463392936".to_string(),
+        decimals: 6,
+        requested: BalanceAtRequested {
+            time: Some(1736536800),
+            slot: None,
+            datetime: None,
+        },
+        as_of: Some(BalanceAtAsOf {
+            slot: 313000000,
+            block_time: Some(1736536794),
+            signature: "5Cyy7Mh9nVgFq3T8wJp2sKxR4dE6bA1uZoNcLrXmYqUpon".to_string(),
+        }),
+    };
+
+    server
+        .mock(
+            "GET",
+            "/v1/wallet/5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9/balance-at?api-key=fake_api_key&mint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&time=1736536800",
+        )
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(serde_json::to_string(&mock_response).unwrap())
+        .create();
+
+    let helius: Helius = make_helius(&url);
+
+    let response: Result<BalanceAtResponse> = helius
+        .get_wallet_balance_at(
+            "5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9",
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            BalanceAtQuery::Time(1736536800),
+        )
+        .await;
+
+    assert!(response.is_ok(), "The API call failed: {:?}", response.err());
+
+    let balance: BalanceAtResponse = response.unwrap();
+    assert_eq!(balance.balance, "284961463.392936");
+    assert_eq!(balance.balance_raw, "284961463392936");
+    assert_eq!(balance.decimals, 6);
+    assert!(!balance.is_native);
+    assert_eq!(balance.requested.time, Some(1736536800));
+    let as_of = balance.as_of.expect("as_of should be present");
+    assert_eq!(as_of.slot, 313000000);
+    assert_eq!(as_of.block_time, Some(1736536794));
+}
+
+#[tokio::test]
+async fn test_get_wallet_balance_at_with_slot() {
+    let mut server: Server = Server::new_with_opts_async(mockito::ServerOpts::default()).await;
+    let url: String = format!("{}/", server.url());
+
+    let mock_response: BalanceAtResponse = BalanceAtResponse {
+        wallet: "5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9".to_string(),
+        mint: "So11111111111111111111111111111111111111111".to_string(),
+        is_native: true,
+        balance: "1.5".to_string(),
+        balance_raw: "1500000000".to_string(),
+        decimals: 9,
+        requested: BalanceAtRequested {
+            time: None,
+            slot: Some(313000000),
+            datetime: None,
+        },
+        as_of: Some(BalanceAtAsOf {
+            slot: 313000000,
+            block_time: None,
+            signature: "5Cyy7Mh9nVgFq3T8wJp2sKxR4dE6bA1uZoNcLrXmYqUpon".to_string(),
+        }),
+    };
+
+    server
+        .mock(
+            "GET",
+            "/v1/wallet/5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9/balance-at?api-key=fake_api_key&mint=So11111111111111111111111111111111111111111&slot=313000000",
+        )
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(serde_json::to_string(&mock_response).unwrap())
+        .create();
+
+    let helius: Helius = make_helius(&url);
+
+    let response: Result<BalanceAtResponse> = helius
+        .get_wallet_balance_at(
+            "5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9",
+            "So11111111111111111111111111111111111111111",
+            BalanceAtQuery::Slot(313000000),
+        )
+        .await;
+
+    assert!(response.is_ok(), "The API call failed: {:?}", response.err());
+
+    let balance: BalanceAtResponse = response.unwrap();
+    assert!(balance.is_native);
+    assert_eq!(balance.decimals, 9);
+    assert_eq!(balance.requested.slot, Some(313000000));
+}
+
+#[tokio::test]
+async fn test_get_wallet_balance_at_with_datetime() {
+    let mut server: Server = Server::new_with_opts_async(mockito::ServerOpts::default()).await;
+    let url: String = format!("{}/", server.url());
+
+    let mock_response: BalanceAtResponse = BalanceAtResponse {
+        wallet: "5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9".to_string(),
+        mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+        is_native: false,
+        balance: "100".to_string(),
+        balance_raw: "100000000".to_string(),
+        decimals: 6,
+        requested: BalanceAtRequested {
+            time: Some(1736536800),
+            slot: None,
+            datetime: Some("2025-01-10 19:20:00".to_string()),
+        },
+        as_of: None,
+    };
+
+    // The datetime value is form-encoded: space becomes `+`.
+    server
+        .mock(
+            "GET",
+            "/v1/wallet/5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9/balance-at?api-key=fake_api_key&mint=EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v&datetime=2025-01-10+19%3A20%3A00",
+        )
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(serde_json::to_string(&mock_response).unwrap())
+        .create();
+
+    let helius: Helius = make_helius(&url);
+
+    let response: Result<BalanceAtResponse> = helius
+        .get_wallet_balance_at(
+            "5tzFkiKscXHK5ZXCGbXZxdw7gTjjD1mBwuoFbhUvuAi9",
+            "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
+            BalanceAtQuery::Datetime("2025-01-10 19:20:00".to_string()),
+        )
+        .await;
+
+    assert!(response.is_ok(), "The API call failed: {:?}", response.err());
+
+    let balance: BalanceAtResponse = response.unwrap();
+    assert_eq!(balance.requested.datetime, Some("2025-01-10 19:20:00".to_string()));
+    assert!(balance.as_of.is_none());
+    assert_eq!(balance.balance, "100");
+}


### PR DESCRIPTION
This PR adds support for the Get Historical Token Balance endpoint (`GET /v1/wallet/{wallet}/balance-at`), which returns a wallet's balance of a specific token (or native SOL) at a past timestamp, datetime, or slot

```rust
let balance = helius
    .get_wallet_balance_at(
        "GQUtvPx89ZNCwmvQqFmH59bJcU8fW8siETpaxod7Aydz",
        "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v",
        BalanceAtQuery::Time(1736536800), // or ::Datetime(s) / ::Slot(n)
    )
    .await?;
println!("{} ({} raw)", balance.balance, balance.balance_raw);
```