### PR TITLE
feat(ci): Require and Enforce Signed Commits

### DIFF
--- a/.github/workflows/verify-signed-commits.yml
+++ b/.github/workflows/verify-signed-commits.yml
@@ -1,0 +1,57 @@
+name: Verify Signed Commits
+
+# Enforces the signed-commits policy (see CONTRIBUTIONS.md).
+# Every commit in a PR must be signed AND verified by GitHub against the
+# author's registered signing key. We query GitHub's verification API rather
+# than `git verify-commit` because CI does not have contributors' public keys.
+
+on:
+  pull_request:
+    branches: [dev, main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  verify-signatures:
+    name: Verify commit signatures
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check that all PR commits are signed and verified
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          echo "Checking commit signatures for PR #$PR_NUMBER in $REPO"
+          echo
+
+          # One compact JSON object per commit: sha, verified flag, and reason.
+          commits=$(gh api --paginate "repos/$REPO/pulls/$PR_NUMBER/commits" \
+            --jq '.[] | {sha: .sha, verified: .commit.verification.verified, reason: .commit.verification.reason}')
+
+          unverified=0
+          while IFS= read -r commit; do
+            [ -z "$commit" ] && continue
+            sha=$(printf '%s' "$commit" | jq -r '.sha' | cut -c1-8)
+            verified=$(printf '%s' "$commit" | jq -r '.verified')
+            reason=$(printf '%s' "$commit" | jq -r '.reason')
+            if [ "$verified" = "true" ]; then
+              echo "  verified    $sha"
+            else
+              echo "  UNVERIFIED  $sha  (reason: $reason)"
+              unverified=$((unverified + 1))
+            fi
+          done <<< "$commits"
+
+          echo
+          if [ "$unverified" -gt 0 ]; then
+            echo "::error::$unverified commit(s) are not signed/verified."
+            echo "All commits must be signed. See CONTRIBUTIONS.md and:"
+            echo "https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits"
+            exit 1
+          fi
+
+          echo "All commits are signed and verified."

--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -15,7 +15,55 @@ Pull Requests are the best way to propose changes to the SDK. We actively welcom
 - Add tests if you've introduced new functionality that should be tested
 - Update the relevant documentation if new functionality is introduced, or current functionality is altered
 - Ensure the test suite passes (`cargo test`)
+- [Sign your commits](#signing-your-commits-required) — **required**; unsigned commits will be rejected
 - Make the pull request!
+
+### Signing Your Commits (Required)
+
+**All commits must be signed and verified.** Pull requests that contain unsigned or unverified commits will fail CI and cannot be merged.
+
+A "verified" commit is one GitHub can cryptographically tie to a registered signing key (GPG, SSH, or S/MIME). It shows a green **Verified** badge in the GitHub UI.
+
+#### One-time setup
+
+Follow GitHub's official guide to generate a signing key and configure Git to sign your commits:
+
+**https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits**
+
+The short version:
+
+1. Generate or choose a signing key (GPG or SSH) — see the guide above.
+2. Add the **public** key to your GitHub account under **Settings → SSH and GPG keys**.
+3. Tell Git to use it and sign every commit automatically:
+
+   ```bash
+   # SSH signing (simplest if you already have an SSH key on GitHub)
+   git config --global gpg.format ssh
+   git config --global user.signingkey ~/.ssh/id_ed25519.pub
+   git config --global commit.gpgsign true
+
+   # — or — GPG signing
+   git config --global user.signingkey <YOUR_KEY_ID>
+   git config --global commit.gpgsign true
+   ```
+
+   Use `--global` to sign across all repos, or drop it to configure just this repo.
+
+4. Confirm the email on your signing key matches a verified email on your GitHub account, otherwise commits show as **Unverified**.
+
+#### Verifying it works
+
+After committing, check the signature locally:
+
+```bash
+git log --show-signature -1
+```
+
+Once pushed, the commit should display a **Verified** badge on GitHub. If you have existing unsigned commits on a branch, you can re-sign them with:
+
+```bash
+git rebase --exec 'git commit --amend --no-edit -S' -i dev
+```
 
 ### Good Pull Request Titles
 - fix(enhanced_transactions): Issue with URL Format


### PR DESCRIPTION
This PR makes signed commits an explicit, enforced requirement for all contributions by documenting it in `CONTRIBUTIONS.md` and adding the new `verify-signed-commits.yml` workflow
