### PR TITLE
fix(repo): Correctness Bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### Fixed
 - Server-side JSON-RPC errors are now surfaced instead of swallowed. Solana/Helius RPC methods report method-level failures (invalid params, unknown method, transaction preflight failures, etc.) as a JSON-RPC `error` object with an HTTP 200 status. Previously `RpcResponse<T>` had no `error` field and a required `result`, so these responses failed to deserialize and returned a misleading `missing field 'result'` error, discarding the real error code and message. `post_rpc_request` now inspects `error` and returns a `HeliusError::RpcError { code, message }` carrying the server's details. Affects all DAS and RPC V2 methods.
+- `send_and_confirm_transaction` now honors its timeout. The retry loop used `||` where it needed `&&`, so it kept retrying until *both* the timeout elapsed *and* the blockhash expired instead of stopping as soon as either did. The timeout error message now reflects the actual configured duration rather than a hardcoded "60s".
+- `get_withdrawable_amount` no longer reports a stake account as withdrawable one epoch early. A stake deactivated in epoch N is still cooling down during epoch N; the check now uses `>=` so funds are only reported withdrawable once `current_epoch > deactivation_epoch`.
+- `create_smart_transaction_with_seeds` now returns `HeliusError::InvalidInput` on a keypair-from-seed failure instead of panicking via `expect`, matching its documented `# Errors` contract.
 
 ## [1.1.0] - 2026-04-29
 

--- a/src/optimized_transaction.rs
+++ b/src/optimized_transaction.rs
@@ -620,8 +620,11 @@ impl Helius {
         let timeout: Duration = timeout.unwrap_or(Duration::from_secs(60));
         let start_time: Instant = Instant::now();
 
+        // Keep retrying only while both conditions hold: there is time left in the timeout
+        // budget AND the blockhash is still valid. Using `&&` stops as soon as either expires;
+        // `||` would keep looping until both elapsed, defeating the timeout.
         while Instant::now().duration_since(start_time) < timeout
-            || self.connection().get_block_height()? <= last_valid_block_height
+            && self.connection().get_block_height()? <= last_valid_block_height
         {
             let result = self
                 .connection()
@@ -643,7 +646,10 @@ impl Helius {
 
         Err(HeliusError::Timeout {
             code: StatusCode::REQUEST_TIMEOUT,
-            text: "Transaction failed to confirm in 60s".to_string(),
+            text: format!(
+                "Transaction failed to confirm within {}s or the blockhash expired",
+                timeout.as_secs()
+            ),
         })
     }
 
@@ -733,12 +739,16 @@ impl Helius {
         let keypairs: Vec<Keypair> = create_config
             .signer_seeds
             .iter()
-            .map(|seed| keypair_from_seed(seed).expect("Failed to create keypair from seed"))
-            .collect();
+            .map(|seed| {
+                keypair_from_seed(seed)
+                    .map_err(|e| HeliusError::InvalidInput(format!("Failed to create keypair from seed: {e}")))
+            })
+            .collect::<Result<Vec<Keypair>>>()?;
 
         // Create the fee payer keypair if provided. Otherwise, we default to the first signer
         let fee_payer: Keypair = if let Some(fee_payer_seed) = create_config.fee_payer_seed {
-            keypair_from_seed(&fee_payer_seed).expect("Failed to create keypair from seed")
+            keypair_from_seed(&fee_payer_seed)
+                .map_err(|e| HeliusError::InvalidInput(format!("Failed to create fee payer keypair from seed: {e}")))?
         } else {
             keypairs[0].insecure_clone()
         };

--- a/src/staking.rs
+++ b/src/staking.rs
@@ -341,8 +341,12 @@ impl Helius {
 
         let current_epoch = self.connection().get_epoch_info()?.epoch;
 
-        if deactivation_epoch > current_epoch {
-            return Ok(0); // Still cooling down
+        // A stake deactivated in epoch N is only withdrawable once epoch N has fully passed
+        // (i.e. current_epoch > deactivation_epoch). During the deactivation epoch itself it is
+        // still cooling down, so `>=` is required here. Active stakes use a sentinel
+        // deactivation_epoch of u64::MAX and are likewise reported as not withdrawable.
+        if deactivation_epoch >= current_epoch {
+            return Ok(0); // Still active or cooling down
         }
 
         if include_rent_exempt {

--- a/tests/smart_transactions/test_send_and_confirm.rs
+++ b/tests/smart_transactions/test_send_and_confirm.rs
@@ -1,0 +1,74 @@
+use std::time::Duration;
+
+use helius::error::HeliusError;
+
+use solana_client::rpc_config::RpcSendTransactionConfig;
+use solana_sdk::{
+    hash::Hash,
+    pubkey::Pubkey,
+    signature::{Keypair, Signer},
+    transaction::Transaction,
+};
+use solana_system_interface::instruction as system_instruction;
+
+use mockito::{Matcher, Server};
+
+use super::helpers::setup_mock;
+
+/// Mocks `getBlockHeight` to return a fixed height.
+fn mock_block_height(server: &mut Server, height: u64) {
+    server
+        .mock("POST", Matcher::Any)
+        .match_body(Matcher::Regex("getBlockHeight".to_string()))
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(format!(r#"{{"jsonrpc":"2.0","result":{height},"id":1}}"#))
+        .create();
+}
+
+fn dummy_transaction() -> Transaction {
+    let payer = Keypair::new();
+    let ix = system_instruction::transfer(&payer.pubkey(), &Pubkey::new_unique(), 1);
+    Transaction::new_signed_with_payer(&[ix], Some(&payer.pubkey()), &[&payer], Hash::default())
+}
+
+/// Once the current block height exceeds `last_valid_block_height`, the blockhash has expired
+/// and `send_and_confirm_transaction` must stop immediately without attempting a send. This
+/// guards the retry-loop condition: with `&&` the loop exits as soon as either the timeout
+/// elapses or the blockhash expires, whereas the previous `||` kept looping (and sending)
+/// until both elapsed.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_stops_when_blockhash_expired() {
+    let (mut server, helius) = setup_mock().await;
+
+    // Current height (200) is already past the last valid height (100) we pass below.
+    mock_block_height(&mut server, 200);
+
+    // If the loop body ever runs, it will POST a sendTransaction — which must not happen.
+    let send_mock = server
+        .mock("POST", Matcher::Any)
+        .match_body(Matcher::Regex("sendTransaction".to_string()))
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(
+            r#"{"jsonrpc":"2.0","result":"1111111111111111111111111111111111111111111111111111111111111111","id":1}"#,
+        )
+        .expect(0)
+        .create();
+
+    let tx = dummy_transaction();
+    let result = helius
+        .send_and_confirm_transaction(
+            &tx,
+            RpcSendTransactionConfig::default(),
+            100,
+            Some(Duration::from_secs(1)),
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(HeliusError::Timeout { .. })),
+        "Expected a Timeout error once the blockhash expired, got {result:?}"
+    );
+    send_mock.assert();
+}

--- a/tests/staking/test_get_withdrawable_amount.rs
+++ b/tests/staking/test_get_withdrawable_amount.rs
@@ -1,0 +1,93 @@
+use base64::Engine;
+use solana_sdk::pubkey::Pubkey;
+use solana_stake_interface::stake_flags::StakeFlags;
+use solana_stake_interface::state::{Meta, Stake, StakeStateV2};
+
+use super::helpers::setup_mock;
+
+use mockito::{Matcher, Server};
+
+/// Base64-encoded bincode of a delegated stake account with the given `deactivation_epoch`.
+fn stake_account_data(deactivation_epoch: u64) -> String {
+    let mut stake = Stake::default();
+    stake.delegation.deactivation_epoch = deactivation_epoch;
+    let state = StakeStateV2::Stake(Meta::default(), stake, StakeFlags::default());
+    let bytes = bincode::serialize(&state).unwrap();
+    base64::engine::general_purpose::STANDARD.encode(bytes)
+}
+
+fn mock_account(server: &mut Server, deactivation_epoch: u64, lamports: u64) {
+    let body = format!(
+        r#"{{"jsonrpc":"2.0","result":{{"context":{{"slot":1}},"value":{{"data":["{}","base64"],"executable":false,"lamports":{},"owner":"Stake11111111111111111111111111111111111111","rentEpoch":18446744073709551615,"space":200}}}},"id":1}}"#,
+        stake_account_data(deactivation_epoch),
+        lamports
+    );
+    server
+        .mock("POST", Matcher::Any)
+        .match_body(Matcher::Regex("getAccountInfo".to_string()))
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(body)
+        .create();
+}
+
+fn mock_epoch(server: &mut Server, epoch: u64) {
+    let body = format!(
+        r#"{{"jsonrpc":"2.0","result":{{"absoluteSlot":100,"blockHeight":100,"epoch":{},"slotIndex":1,"slotsInEpoch":432000,"transactionCount":1}},"id":1}}"#,
+        epoch
+    );
+    server
+        .mock("POST", Matcher::Any)
+        .match_body(Matcher::Regex("getEpochInfo".to_string()))
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(body)
+        .create();
+}
+
+/// A stake deactivated in epoch N is still cooling down during epoch N itself, so a query at
+/// current_epoch == deactivation_epoch must report 0 withdrawable (the off-by-one boundary).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_withdrawable_zero_during_deactivation_epoch() {
+    let (mut server, helius) = setup_mock().await;
+    mock_account(&mut server, 10, 5_000_000_000);
+    mock_epoch(&mut server, 10);
+
+    let stake_account = Pubkey::new_unique();
+    let amount = helius.get_withdrawable_amount(stake_account, true).await.unwrap();
+
+    assert_eq!(
+        amount, 0,
+        "Stake in its deactivation epoch must not be withdrawable yet"
+    );
+}
+
+/// Once the deactivation epoch has fully passed (current_epoch > deactivation_epoch), the full
+/// balance is withdrawable when rent-exempt lamports are included.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_withdrawable_after_cooldown() {
+    let (mut server, helius) = setup_mock().await;
+    mock_account(&mut server, 10, 5_000_000_000);
+    mock_epoch(&mut server, 11);
+
+    let stake_account = Pubkey::new_unique();
+    let amount = helius.get_withdrawable_amount(stake_account, true).await.unwrap();
+
+    assert_eq!(
+        amount, 5_000_000_000,
+        "Cooled-down stake should report its full balance"
+    );
+}
+
+/// An active (never-deactivated) stake uses the u64::MAX sentinel and is never withdrawable.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_withdrawable_zero_for_active_stake() {
+    let (mut server, helius) = setup_mock().await;
+    mock_account(&mut server, u64::MAX, 5_000_000_000);
+    mock_epoch(&mut server, 300);
+
+    let stake_account = Pubkey::new_unique();
+    let result = helius.get_withdrawable_amount(stake_account, true).await;
+
+    assert!(matches!(result, Ok(0)), "Active stake must report 0, got {result:?}");
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -50,6 +50,7 @@ mod smart_transactions {
     mod helpers;
     mod test_create_smart_transaction;
     mod test_input_validation;
+    mod test_send_and_confirm;
     mod test_sender_urls;
 }
 mod websocket {
@@ -64,6 +65,7 @@ mod staking {
     mod test_create_withdraw_transaction;
     mod test_get_unstake_instruction;
     mod test_get_withdraw_instruction;
+    mod test_get_withdrawable_amount;
 }
 mod zk_compression {
     mod helpers;


### PR DESCRIPTION
## Overview
This PR fixes three correctness issues found during the codebase audit, bundled because each is small, isolated, and test-backed

### 1. `send_and_confirm_transaction` ignores its timeout
The retry-loop guard used `||` where it needed `&&`, so the loop kept retrying until *both* the timeout elapsed *and* the blockhash expired, instead of stopping as soon as either did. The documented 60s bound did not hold. Fixed to `&&`; the timeout error now reports the actual configured duration

### 2. `get_withdrawable_amount` off-by-one
A stake deactivated in epoch N is still cooling down during epoch N and only becomes withdrawable at N+1. The check used `>` and so reported the balance as withdrawable an epoch early. Fixed to `>=`

### 3. `create_smart_transaction_with_seeds` panic-in-principle
The seed→keypair mapping used `.expect()`, contradicting the function's documented `# Errors` contract. Now returns `HeliusError::InvalidInput`. Note: the seed type is `[u8; 32]` and `keypair_from_seed` only fails on seeds shorter than 32 bytes, so this path is **not reachable today**, so this is defensive hardening, not a live bug fix.

## Testing
- New `tests/staking/test_get_withdrawable_amount.rs` (3 tests) — covers the deactivation-epoch boundary, post-cooldown, and active-stake sentinel. Confirmed to fail on the old `>`
- New `tests/smart_transactions/test_send_and_confirm.rs` — confirms no `sendTransaction` is attempted once the blockhash has expired. Confirmed to fail on the old `||`
- `cargo fmt --check` clean, `cargo clippy` no new warnings, full suite passes (326 tests)