### PR TITLE
fix(error): Prevent Panic on Empty getSignatureStatuses, and Propagate URL Parse Errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - `send_and_confirm_transaction` now honors its timeout. The retry loop used `||` where it needed `&&`, so it kept retrying until *both* the timeout elapsed *and* the blockhash expired instead of stopping as soon as either did. The timeout error message now reflects the actual configured duration rather than a hardcoded "60s".
 - `get_withdrawable_amount` no longer reports a stake account as withdrawable one epoch early. A stake deactivated in epoch N is still cooling down during epoch N; the check now uses `>=` so funds are only reported withdrawable once `current_epoch > deactivation_epoch`.
 - `create_smart_transaction_with_seeds` now returns `HeliusError::InvalidInput` on a keypair-from-seed failure instead of panicking via `expect`, matching its documented `# Errors` contract.
+- `poll_transaction_confirmation` no longer panics if `getSignatureStatuses` returns an empty `value` array (e.g. from a misbehaving provider); a missing status entry is now treated as "not yet confirmed" and retried.
+- Hardened per-request URL construction across the Wallet, Webhook, enhanced-transaction, and admin APIs (and `post_rpc_request`): `Url::parse` failures now propagate as `HeliusError::UrlParseError` instead of panicking via `expect`. In practice the `url` parser tolerates the interpolated values, so this is defensive; behavior is unchanged for all valid inputs.
 
 ## [1.1.0] - 2026-04-29
 

--- a/src/admin.rs
+++ b/src/admin.rs
@@ -66,7 +66,7 @@ impl Helius {
             project_id,
             api_key.as_str()
         );
-        let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
+        let parsed_url: Url = Url::parse(&url)?;
 
         self.rpc_client.handler.send(Method::GET, parsed_url, None::<&()>).await
     }

--- a/src/enhanced_transactions.rs
+++ b/src/enhanced_transactions.rs
@@ -20,7 +20,7 @@ impl Helius {
             self.config.endpoints.api,
             api_key.as_str()
         );
-        let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
+        let parsed_url: Url = Url::parse(&url)?;
 
         self.rpc_client
             .handler
@@ -73,7 +73,7 @@ impl Helius {
             url = format!("{}&limit={}", url, limit);
         }
 
-        let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
+        let parsed_url: Url = Url::parse(&url)?;
 
         self.rpc_client.handler.send(Method::GET, parsed_url, None::<&()>).await
     }

--- a/src/optimized_transaction.rs
+++ b/src/optimized_transaction.rs
@@ -405,7 +405,10 @@ impl Helius {
 
             let status = self.connection().get_signature_statuses(&[txt_sig])?;
 
-            match status.value[0].clone() {
+            // `value` should hold exactly one entry for the single signature queried, but guard
+            // against an empty/short response by treating a missing entry as "not yet available"
+            // (retry) rather than indexing and panicking.
+            match status.value.first().cloned().flatten() {
                 Some(status) => {
                     if status.err.is_none()
                         && (status.confirmation_status == Some(TransactionConfirmationStatus::Confirmed)

--- a/src/rpc_client.rs
+++ b/src/rpc_client.rs
@@ -124,7 +124,7 @@ impl RpcClient {
         T: Debug + DeserializeOwned + Default,
     {
         let base_url: String = self.config.build_rpc_url();
-        let url: Url = Url::parse(&base_url).expect("Failed to parse URL");
+        let url: Url = Url::parse(&base_url)?;
 
         let rpc_request: RpcRequest<R> = RpcRequest::new(method.to_string(), request);
         let rpc_response: RpcResponse<T> = self.handler.send(Method::POST, url, Some(&rpc_request)).await?;

--- a/src/wallet.rs
+++ b/src/wallet.rs
@@ -63,7 +63,7 @@ impl Helius {
         let api_key = self.config.require_api_key("wallet identity")?;
         let base_url = self.get_wallet_api_base_url();
         let url: String = format!("{}v1/wallet/{}/identity?api-key={}", base_url, wallet, api_key.as_str());
-        let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
+        let parsed_url: Url = Url::parse(&url)?;
 
         self.rpc_client.handler.send(Method::GET, parsed_url, None::<&()>).await
     }
@@ -107,7 +107,7 @@ impl Helius {
         let api_key = self.config.require_api_key("batch wallet identity")?;
         let base_url = self.get_wallet_api_base_url();
         let url: String = format!("{}v1/wallet/batch-identity?api-key={}", base_url, api_key.as_str());
-        let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
+        let parsed_url: Url = Url::parse(&url)?;
 
         let request = BatchIdentityRequest {
             addresses: addresses.to_vec(),
@@ -201,7 +201,7 @@ impl Helius {
             url = format!("{}&showNfts={}", url, show_nfts);
         }
 
-        let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
+        let parsed_url: Url = Url::parse(&url)?;
 
         self.rpc_client.handler.send(Method::GET, parsed_url, None::<&()>).await
     }
@@ -290,7 +290,7 @@ impl Helius {
             url = format!("{}&tokenAccounts={}", url, token_accounts);
         }
 
-        let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
+        let parsed_url: Url = Url::parse(&url)?;
 
         self.rpc_client.handler.send(Method::GET, parsed_url, None::<&()>).await
     }
@@ -360,7 +360,7 @@ impl Helius {
             url = format!("{}&cursor={}", url, cursor);
         }
 
-        let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
+        let parsed_url: Url = Url::parse(&url)?;
 
         self.rpc_client.handler.send(Method::GET, parsed_url, None::<&()>).await
     }
@@ -413,7 +413,7 @@ impl Helius {
             wallet,
             api_key.as_str()
         );
-        let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
+        let parsed_url: Url = Url::parse(&url)?;
 
         self.rpc_client.handler.send(Method::GET, parsed_url, None::<&()>).await
     }
@@ -480,7 +480,7 @@ impl Helius {
             mint
         );
 
-        let mut parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
+        let mut parsed_url: Url = Url::parse(&url)?;
 
         // Append the time selector with form-encoding so datetime values containing
         // spaces or `+` timezone offsets survive transport intact.

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -15,7 +15,7 @@ impl Helius {
     pub async fn create_webhook(&self, request: CreateWebhookRequest) -> Result<Webhook> {
         let api_key = self.config.require_api_key("webhook operations")?;
         let url: String = format!("{}v0/webhooks?api-key={}", self.config.endpoints.api, api_key.as_str());
-        let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
+        let parsed_url: Url = Url::parse(&url)?;
 
         self.rpc_client
             .handler
@@ -38,7 +38,7 @@ impl Helius {
             request.webhook_id,
             api_key.as_str()
         );
-        let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
+        let parsed_url: Url = Url::parse(&url)?;
 
         self.rpc_client
             .handler
@@ -118,7 +118,7 @@ impl Helius {
             webhook_id,
             api_key.as_str()
         );
-        let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
+        let parsed_url: Url = Url::parse(&url)?;
 
         self.rpc_client.handler.send(Method::GET, parsed_url, None::<&()>).await
     }
@@ -132,7 +132,7 @@ impl Helius {
     pub async fn get_all_webhooks(&self) -> Result<Vec<Webhook>> {
         let api_key = self.config.require_api_key("webhook operations")?;
         let url: String = format!("{}v0/webhooks?api-key={}", self.config.endpoints.api, api_key.as_str());
-        let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
+        let parsed_url: Url = Url::parse(&url)?;
 
         self.rpc_client.handler.send(Method::GET, parsed_url, None::<&()>).await
     }
@@ -156,7 +156,7 @@ impl Helius {
             request.webhook_id,
             api_key.as_str()
         );
-        let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
+        let parsed_url: Url = Url::parse(&url)?;
 
         self.rpc_client
             .handler
@@ -179,7 +179,7 @@ impl Helius {
             webhook_id,
             api_key.as_str()
         );
-        let parsed_url: Url = Url::parse(&url).expect("Failed to parse URL");
+        let parsed_url: Url = Url::parse(&url)?;
 
         self.rpc_client
             .handler

--- a/tests/smart_transactions/test_poll_confirmation.rs
+++ b/tests/smart_transactions/test_poll_confirmation.rs
@@ -1,0 +1,42 @@
+use std::time::Duration;
+
+use solana_sdk::signature::Signature;
+
+use mockito::{Matcher, Server};
+
+use super::helpers::setup_mock;
+
+/// Mocks `getSignatureStatuses` to return an empty `value` array, as a misbehaving provider
+/// might. The previous `status.value[0]` index would panic on this; the fix treats a missing
+/// entry as "not yet available" and keeps retrying.
+fn mock_empty_signature_statuses(server: &mut Server) {
+    server
+        .mock("POST", Matcher::Any)
+        .match_body(Matcher::Regex("getSignatureStatuses".to_string()))
+        .with_status(200)
+        .with_header("Content-Type", "application/json")
+        .with_body(r#"{"jsonrpc":"2.0","result":{"context":{"slot":1},"value":[]},"id":1}"#)
+        .create();
+}
+
+/// An empty `getSignatureStatuses` response must not panic the confirmation poll — it should
+/// keep retrying until it times out. We assert the spawned poll is still running (retrying)
+/// shortly after the response, rather than having panicked (which resolves the join handle).
+#[tokio::test(flavor = "multi_thread")]
+async fn test_poll_confirmation_empty_status_does_not_panic() {
+    let (mut server, helius) = setup_mock().await;
+    mock_empty_signature_statuses(&mut server);
+
+    let handle = tokio::spawn(async move { helius.poll_transaction_confirmation(Signature::default()).await });
+
+    // Long enough to make the RPC call and enter the retry sleep, but shorter than the 5s
+    // retry interval so the poll is still in-flight (not yet timed out).
+    tokio::time::sleep(Duration::from_secs(2)).await;
+
+    assert!(
+        !handle.is_finished(),
+        "poll should still be retrying after an empty status response, not panicked or returned"
+    );
+
+    handle.abort();
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -50,6 +50,7 @@ mod smart_transactions {
     mod helpers;
     mod test_create_smart_transaction;
     mod test_input_validation;
+    mod test_poll_confirmation;
     mod test_send_and_confirm;
     mod test_sender_urls;
 }


### PR DESCRIPTION
This PR turns two classes of `panic!`-via-`expect`/indexing into proper `HeliusError` returns

### 1. `poll_transaction_confirmation` panic on empty status
The confirmation poll indexed `status.value[0]` on the `getSignatureStatuses` response. If a provider returns an empty `value` array, that indexing panics the caller's task. Now uses `status.value.first().cloned().flatten()`, treating a missing entry as "not yet confirmed" and retrying — the same path as a `None` status

### 2. URL parse `expect` → `?` (defensive)
Replaced `Url::parse(&url).expect("Failed to parse URL")` with `?` at 17 call sites across the Wallet, Webhook, enhanced-transaction, and admin APIs and `post_rpc_request`, so a parse failure returns `HeliusError::UrlParseError` instead of panicking

## Testing
- New `tests/smart_transactions/test_poll_confirmation.rs` (~2s, deterministic): spawns the poll against a mock returning an empty `value` array and asserts it is still retrying (not panicked) after 2s. Confirmed it **fails on the old `[0]` index** and passes on the fix
- `cargo fmt --check` clean, `cargo clippy` no new warnings, full suite passes (327 tests)
