### PR TITLE
chore(clippy): Fix Clippy Lints, Remove Redundant CU Checks, Sync llms.txt Version

### DIFF
--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@ last_updated: 2026-05-05
 The Helius Rust SDK provides asynchronous access to Helius APIs and enhanced Solana RPC functionality. It simplifies Solana development with high-level abstractions for assets, transactions, webhooks, staking, and ultra-low latency transaction submission via Helius Sender.
 
 - Crate: `helius` (crates.io)
-- Version: 1.0.x
+- Version: 1.1.x
 - Changelog: https://github.com/helius-labs/helius-rust-sdk/blob/dev/CHANGELOG.md
 - Rust: 1.85+ (edition 2021)
 - Async Runtime: tokio
@@ -43,7 +43,7 @@ Use the Helius Rust SDK when you need to:
 Add to your `Cargo.toml`:
 ```toml
 [dependencies]
-helius = "1.0"
+helius = "1.1"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 

--- a/src/optimized_transaction.rs
+++ b/src/optimized_transaction.rs
@@ -522,12 +522,6 @@ impl Helius {
             )
             .await?;
 
-        if units.is_none() {
-            return Err(HeliusError::InvalidInput(
-                "Error fetching compute units for the instructions provided".to_string(),
-            ));
-        }
-
         let compute_units: u64 = units.ok_or(HeliusError::InvalidInput(
             "Error fetching compute units for the instructions provided".to_string(),
         ))?;
@@ -1005,12 +999,6 @@ impl Helius {
             )
             .await?;
 
-        if units.is_none() {
-            return Err(HeliusError::InvalidInput(
-                "Error fetching compute units for the provided instructions".to_string(),
-            ));
-        }
-
         let compute_units: u64 = units.ok_or(HeliusError::InvalidInput(
             "Error fetching compute units for the instructions provided".to_string(),
         ))?;
@@ -1371,7 +1359,7 @@ mod tests {
         instruction::{AccountMeta, Instruction, InstructionError},
         message::{v0, VersionedMessage},
         pubkey::Pubkey,
-        signature::{Keypair, Signature, Signer},
+        signature::{Keypair, Signer},
         transaction::{Transaction, TransactionError, VersionedTransaction},
     };
     use std::sync::Arc;
@@ -1441,9 +1429,9 @@ mod tests {
         assert_eq!(
             tx.signatures,
             vec![
-                Signature::from(fee_payer.sign_message(&message_bytes)),
-                Signature::from(writable_signer.sign_message(&message_bytes)),
-                Signature::from(readonly_signer.sign_message(&message_bytes)),
+                fee_payer.sign_message(&message_bytes),
+                writable_signer.sign_message(&message_bytes),
+                readonly_signer.sign_message(&message_bytes),
             ]
         );
     }
@@ -1511,9 +1499,9 @@ mod tests {
         assert_eq!(
             tx.signatures,
             vec![
-                Signature::from(fee_payer.sign_message(&message_bytes)),
-                Signature::from(writable_signer.sign_message(&message_bytes)),
-                Signature::from(readonly_signer.sign_message(&message_bytes)),
+                fee_payer.sign_message(&message_bytes),
+                writable_signer.sign_message(&message_bytes),
+                readonly_signer.sign_message(&message_bytes),
             ]
         );
     }

--- a/tests/wallet/test_get_wallet_balances.rs
+++ b/tests/wallet/test_get_wallet_balances.rs
@@ -93,7 +93,7 @@ async fn test_get_wallet_balances_success() {
     assert_eq!(balances.balances.len(), 2);
     assert_eq!(balances.total_usd_value, 18025.80);
     assert_eq!(balances.pagination.page, 1);
-    assert_eq!(balances.pagination.has_more, false);
+    assert!(!balances.pagination.has_more);
     assert_eq!(balances.balances[0].symbol, Some("SOL".to_string()));
 }
 
@@ -158,5 +158,5 @@ async fn test_get_wallet_balances_with_pagination() {
 
     let balances: BalancesResponse = response.unwrap();
     assert_eq!(balances.pagination.page, 2);
-    assert_eq!(balances.pagination.has_more, true);
+    assert!(balances.pagination.has_more);
 }

--- a/tests/wallet/test_get_wallet_history.rs
+++ b/tests/wallet/test_get_wallet_history.rs
@@ -85,7 +85,7 @@ async fn test_get_wallet_history_success() {
     let history: HistoryResponse = response.unwrap();
     assert_eq!(history.data.len(), 1);
     assert_eq!(history.data[0].balance_changes.len(), 2);
-    assert_eq!(history.pagination.has_more, true);
+    assert!(history.pagination.has_more);
     assert!(history.pagination.next_cursor.is_some());
 }
 
@@ -146,5 +146,5 @@ async fn test_get_wallet_history_with_pagination() {
     assert!(response.is_ok());
 
     let history: HistoryResponse = response.unwrap();
-    assert_eq!(history.pagination.has_more, false);
+    assert!(!history.pagination.has_more);
 }

--- a/tests/wallet/test_get_wallet_transfers.rs
+++ b/tests/wallet/test_get_wallet_transfers.rs
@@ -83,7 +83,7 @@ async fn test_get_wallet_transfers_success() {
     assert_eq!(transfers.data.len(), 2);
     assert_eq!(transfers.data[0].direction, TransferDirection::In);
     assert_eq!(transfers.data[1].direction, TransferDirection::Out);
-    assert_eq!(transfers.pagination.has_more, true);
+    assert!(transfers.pagination.has_more);
 }
 
 #[tokio::test]
@@ -140,5 +140,5 @@ async fn test_get_wallet_transfers_with_cursor() {
     assert!(response.is_ok());
 
     let transfers: TransfersResponse = response.unwrap();
-    assert_eq!(transfers.pagination.has_more, false);
+    assert!(!transfers.pagination.has_more);
 }


### PR DESCRIPTION
This PR is a cleanup pass that clears clippy noise, removes dead code, and fixes stale docs. We do not introduce any user-facing API or behavior changes in this PR

`cargo fmt --check` clean, `cargo clippy` down to the single deferred deprecation, full suite passes