### PR TITLE
chore(release): Prepare 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-08-13
+
 ### Added
 - **Pre Confirmations** (`preconfSubscribe`): new standalone `preconf::PreconfClient` for Helius's lowest-latency transaction stream, delivering scheduled transactions over WebSocket before they are shredded. Yields a stream of `PreconfNotification { version, slot, transaction_index, status, transaction, transaction_bytes }`, deserializing the bincode `VersionedTransaction` and exposing the raw bytes. Served from the Gatekeeper endpoint (`wss://beta.helius-rpc.com`). Notifications are **binary** frames (the subscribe ack is a JSON text frame); the little-endian layout is `version:u8 | slot:u64_le | transaction_index:u64_le | status:u8 | bincode(VersionedTransaction)`. The `version` byte is checked first (currently `1`; unknown versions are dropped) and `status` is exposed as the `PreconfStatus` enum (`Failed = 0`, `Success = 1`, `Unknown = 2`). Credit-based pricing (10 credits per notification). Includes `PreconfClient::connect`/`connect_with_api_key`/`shutdown`, `PreconfStream`, `CURRENT_VERSION`, and `examples/websockets/preconf_subscribe.rs`. A pre-confirmation is an early signal, not a guarantee; coverage is not continuous (scales with stake forwarding to Helius — expect gaps).
 - **Sender Max bundles**: new `send_bundle_with_sender` submits up to 5 transactions to Sender Max via `sendBundle` (`params: [[base64Tx, ...], { encoding: "base64" }]`). The caller includes only the 0.001 SOL Sender tip in ≥1 transaction; Helius adds any pathway tips — callers must not add a separate pathway-specific tip. Landing is tracked per-transaction by signature (not bundle IDs / `getBundleStatuses`).
@@ -240,7 +242,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Integration test suite using `mockito`
 - GitHub Actions CI workflow
 
-[Unreleased]: https://github.com/helius-labs/helius-rust-sdk/compare/v1.1.0...HEAD
+[Unreleased]: https://github.com/helius-labs/helius-rust-sdk/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/helius-labs/helius-rust-sdk/compare/v1.1.0...v2.0.0
 [1.1.0]: https://github.com/helius-labs/helius-rust-sdk/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/helius-labs/helius-rust-sdk/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/helius-labs/helius-rust-sdk/compare/v0.5.1...v1.0.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "helius"
-version = "1.1.0"
+version = "2.0.0"
 rust-version = "1.85.1"
 edition = "2021"
 description = "An asynchronous Helius Rust SDK for building the future of Solana"

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -8,12 +8,12 @@ update your code. The most recent upgrade is listed first.
 
 ---
 
-# 1.x → 2.0
+## 1.x → 2.0
 
 2.0 is a correctness-focused release. Most breaking changes are narrow type refinements — many
 codebases need no changes, or only trivial ones. Each change below includes what to do.
 
-## Summary of Changes
+### Summary of Changes
 
 - **`RpcResponse<T>` fields are now optional**: `result` is `Option<T>`, `id` is `Option<String>`, and there is a new `error` field. Only affects code that inspects `RpcResponse` directly.
 - **`SenderSendOptions` is `#[non_exhaustive]`**: construct it via `default()`/`new()` + builder methods instead of a struct literal.
@@ -22,7 +22,7 @@ codebases need no changes, or only trivial ones. Each change below includes what
 - **`EnhancedTransaction.fee` and `.slot` are now `u64`** (were `i32`).
 - **Sender tip defaults changed**: the non-SWQOS tier ("Sender Max") now floors tips at 0.001 SOL.
 
-## `RpcResponse<T>`
+### `RpcResponse<T>`
 
 Server-side JSON-RPC errors (invalid params, unknown method, etc.) are now surfaced as
 `HeliusError::RpcError { code, message }` instead of a misleading deserialization error. To model
@@ -53,7 +53,7 @@ let asset = response.result;
 let asset = response.result.ok_or_else(|| /* your error */)?;
 ```
 
-## `SenderSendOptions` is `#[non_exhaustive]`
+### `SenderSendOptions` is `#[non_exhaustive]`
 
 Struct-literal construction no longer compiles. Use the constructors and builder methods:
 
@@ -69,7 +69,7 @@ let opts = SenderSendOptions::new()
 
 Reading and writing fields on an existing value is unchanged.
 
-## `ProgramName::Unkown` → `ProgramName::Unknown`
+### `ProgramName::Unkown` → `ProgramName::Unknown`
 
 Rename any references. Previously the typo'd variant serialized to `"UNKOWN"` and the API's real
 `"UNKNOWN"` fell through to `ProgramName::Other("UNKNOWN")`, so if you matched that string via
@@ -83,7 +83,7 @@ ProgramName::Other(s) if s == "UNKNOWN" => { /* ... */ }
 ProgramName::Unknown => { /* ... */ }
 ```
 
-## Numeric type refinements
+### Numeric type refinements
 
 `limit`, `fee`, and `slot` are non-negative, so they moved from signed to unsigned types:
 
@@ -96,7 +96,7 @@ ProgramName::Unknown => { /* ... */ }
 Integer literals (`Some(1000)`, `assert_eq!(tx.fee, 5000)`) need no change. Update only code that
 stored these in an explicit `i32`/`i64` binding or did signed arithmetic on them.
 
-## Sender tip defaults
+### Sender tip defaults
 
 The non-SWQOS Sender tier is now branded **Sender Max** and floors tips at **0.001 SOL**
 (`MIN_TIP_LAMPORTS_MAX = 1_000_000`), up from the removed 0.0002 SOL tier. SWQOS-only
@@ -105,11 +105,11 @@ The non-SWQOS Sender tier is now branded **Sender Max** and floors tips at **0.0
 
 ---
 
-# 0.x → 1.0
+## 0.x → 1.0
 
 This section covers the breaking changes in the Helius Rust SDK 1.0 release and how to update your code.
 
-## Summary of Changes
+### Summary of Changes
 
 - **Simplified constructors**: 6 constructors replaced with 3 (`new`, `new_async`, `new_with_url`)
 - **New `HeliusBuilder`**: Builder pattern for advanced configuration
@@ -120,9 +120,9 @@ This section covers the breaking changes in the Helius Rust SDK 1.0 release and 
 - **Jito methods removed**: Use Helius Sender instead
 - **`UiTransactionEncoding` serialization fixed**: Variants now serialize as lowercase (`"json"`, `"jsonParsed"`)
 
-## Constructor Changes
+### Constructor Changes
 
-### `Helius::new()` — unchanged signature, still sync
+#### `Helius::new()` — unchanged signature, still sync
 
 ```rust
 // Before (0.x)
@@ -132,7 +132,7 @@ let helius = Helius::new("api-key", Cluster::MainnetBeta)?;
 let helius = Helius::new("api-key", Cluster::MainnetBeta)?;
 ```
 
-### Removed constructors — use `HeliusBuilder` instead
+#### Removed constructors — use `HeliusBuilder` instead
 
 | Removed Constructor | Replacement |
 |---|---|
@@ -142,7 +142,7 @@ let helius = Helius::new("api-key", Cluster::MainnetBeta)?;
 | `new_with_ws(key, cluster)` | `Helius::new_async(key, cluster).await?` |
 | `new_with_ws_with_timeouts(key, cluster, ping, pong)` | `HeliusBuilder::new().with_api_key(key)?.with_cluster(cluster).with_websocket(ping, pong).build().await?` |
 
-### New constructors
+#### New constructors
 
 ```rust
 // Full-featured: async Solana + WebSocket + confirmed commitment (async)
@@ -152,7 +152,7 @@ let helius = Helius::new_async("api-key", Cluster::MainnetBeta).await?;
 let helius = Helius::new_with_url("http://localhost:8899")?;
 ```
 
-## Config Struct Changes
+### Config Struct Changes
 
 The `Config` struct has two new fields:
 
@@ -175,7 +175,7 @@ let config = Config {
 };
 ```
 
-### Accessing the API key
+#### Accessing the API key
 
 ```rust
 // Before (0.x)
@@ -190,7 +190,7 @@ if config.has_api_key() {
 }
 ```
 
-## HeliusBuilder (New)
+### HeliusBuilder (New)
 
 The builder provides fine-grained control over client configuration:
 
@@ -209,7 +209,7 @@ let helius = HeliusBuilder::new()
     .await?;
 ```
 
-### Custom URL with builder
+#### Custom URL with builder
 
 ```rust
 let helius = HeliusBuilder::new()
@@ -220,7 +220,7 @@ let helius = HeliusBuilder::new()
     .await?;
 ```
 
-## Jito Methods Removed
+### Jito Methods Removed
 
 All Jito methods (deprecated in 0.3.0) have been removed. Use Helius Sender instead:
 
@@ -245,7 +245,7 @@ let sig = helius.send_smart_transaction_with_sender(config, Some(SendOptions {
 })).await?;
 ```
 
-## UiTransactionEncoding Serialization Fix
+### UiTransactionEncoding Serialization Fix
 
 `UiTransactionEncoding` variants now serialize as lowercase camelCase to match the Solana RPC spec. If you were passing raw encoding strings to work around this bug, you can now use the enum directly:
 
@@ -259,7 +259,7 @@ let encoding = UiTransactionEncoding::Json;       // serializes as "json"
 let encoding = UiTransactionEncoding::JsonParsed;  // serializes as "jsonParsed"
 ```
 
-## Quick Find-and-Replace
+### Quick Find-and-Replace
 
 For most codebases, these replacements will cover the migration:
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,6 +1,113 @@
-# Migration Guide: 0.x to 1.0
+# Migration Guide
 
-This guide covers the breaking changes in the Helius Rust SDK 1.0 release and how to update your code.
+This guide covers breaking changes between major releases of the Helius Rust SDK and how to
+update your code. The most recent upgrade is listed first.
+
+- [1.x → 2.0](#1x--20)
+- [0.x → 1.0](#0x--10)
+
+---
+
+# 1.x → 2.0
+
+2.0 is a correctness-focused release. Most breaking changes are narrow type refinements — many
+codebases need no changes, or only trivial ones. Each change below includes what to do.
+
+## Summary of Changes
+
+- **`RpcResponse<T>` fields are now optional**: `result` is `Option<T>`, `id` is `Option<String>`, and there is a new `error` field. Only affects code that inspects `RpcResponse` directly.
+- **`SenderSendOptions` is `#[non_exhaustive]`**: construct it via `default()`/`new()` + builder methods instead of a struct literal.
+- **`ProgramName::Unkown` renamed to `ProgramName::Unknown`**: fixes a typo that never matched the API's `"UNKNOWN"`.
+- **`GetAssetsByOwner.limit` is now `Option<u32>`** (was `Option<i32>`).
+- **`EnhancedTransaction.fee` and `.slot` are now `u64`** (were `i32`).
+- **Sender tip defaults changed**: the non-SWQOS tier ("Sender Max") now floors tips at 0.001 SOL.
+
+## `RpcResponse<T>`
+
+Server-side JSON-RPC errors (invalid params, unknown method, etc.) are now surfaced as
+`HeliusError::RpcError { code, message }` instead of a misleading deserialization error. To model
+this, the envelope changed:
+
+```rust
+// Before
+pub struct RpcResponse<T> { pub jsonrpc: String, pub id: String, pub result: T }
+
+// After
+pub struct RpcResponse<T> {
+    pub jsonrpc: String,
+    pub id: Option<String>,
+    pub result: Option<T>,
+    pub error: Option<RpcError>,
+}
+```
+
+**If you call the high-level methods** (`helius.rpc().get_asset(...)`, etc.) you are unaffected —
+they still return `T`, and now return `Err(HeliusError::RpcError { .. })` on a server error.
+
+**If you read `RpcResponse` directly**, handle the `Option`:
+
+```rust
+// Before
+let asset = response.result;
+// After
+let asset = response.result.ok_or_else(|| /* your error */)?;
+```
+
+## `SenderSendOptions` is `#[non_exhaustive]`
+
+Struct-literal construction no longer compiles. Use the constructors and builder methods:
+
+```rust
+// Before
+let opts = SenderSendOptions { region: Some(r), swqos_only: true, ..Default::default() };
+
+// After
+let opts = SenderSendOptions::new()
+    .with_region(r)
+    .with_swqos_only(true);
+```
+
+Reading and writing fields on an existing value is unchanged.
+
+## `ProgramName::Unkown` → `ProgramName::Unknown`
+
+Rename any references. Previously the typo'd variant serialized to `"UNKOWN"` and the API's real
+`"UNKNOWN"` fell through to `ProgramName::Other("UNKNOWN")`, so if you matched that string via
+`Other`, switch to the typed variant:
+
+```rust
+// Before
+ProgramName::Unkown => { /* ... */ }
+ProgramName::Other(s) if s == "UNKNOWN" => { /* ... */ }
+// After
+ProgramName::Unknown => { /* ... */ }
+```
+
+## Numeric type refinements
+
+`limit`, `fee`, and `slot` are non-negative, so they moved from signed to unsigned types:
+
+```rust
+// GetAssetsByOwner.limit:      Option<i32> -> Option<u32>
+// EnhancedTransaction.fee:     i32         -> u64
+// EnhancedTransaction.slot:    i32         -> u64
+```
+
+Integer literals (`Some(1000)`, `assert_eq!(tx.fee, 5000)`) need no change. Update only code that
+stored these in an explicit `i32`/`i64` binding or did signed arithmetic on them.
+
+## Sender tip defaults
+
+The non-SWQOS Sender tier is now branded **Sender Max** and floors tips at **0.001 SOL**
+(`MIN_TIP_LAMPORTS_MAX = 1_000_000`), up from the removed 0.0002 SOL tier. SWQOS-only
+(`swqos_only = true`) is unchanged at 0.000005 SOL. `MIN_TIP_LAMPORTS_DUAL` is deprecated; use
+`MIN_TIP_LAMPORTS_MAX`. If you relied on the old lower non-SWQOS floor, budget for the higher tip.
+
+---
+
+# 0.x → 1.0
+
+This section covers the breaking changes in the Helius Rust SDK 1.0 release and how to update your code.
 
 ## Summary of Changes
 

--- a/README.md
+++ b/README.md
@@ -314,5 +314,5 @@ Admin API access is feature-gated per project and served from `https://admin-api
 - [`is_valid_solana_address`](https://github.com/helius-labs/helius-rust-sdk/blob/dev/src/utils/is_valid_solana_address.rs) - Returns whether a given string slice is a valid Solana address
 - [`make_keypairs`](https://github.com/helius-labs/helius-rust-sdk/blob/dev/src/utils/make_keypairs.rs) - Generates a specified number of keypairs
 
-## Migrating from 0.x
-If you're upgrading from 0.x, see the [Migration Guide](MIGRATION.md) for details on breaking changes and how to update your code.
+## Migrating Between Major Versions
+Upgrading across a major version? See the [Migration Guide](MIGRATION.md) for the breaking changes in each release (1.x → 2.0 and 0.x → 1.0) and how to update your code.

--- a/llms.txt
+++ b/llms.txt
@@ -12,7 +12,7 @@ last_updated: 2026-05-05
 The Helius Rust SDK provides asynchronous access to Helius APIs and enhanced Solana RPC functionality. It simplifies Solana development with high-level abstractions for assets, transactions, webhooks, staking, and ultra-low latency transaction submission via Helius Sender.
 
 - Crate: `helius` (crates.io)
-- Version: 1.1.x
+- Version: 2.0.x
 - Changelog: https://github.com/helius-labs/helius-rust-sdk/blob/dev/CHANGELOG.md
 - Rust: 1.85+ (edition 2021)
 - Async Runtime: tokio
@@ -43,7 +43,7 @@ Use the Helius Rust SDK when you need to:
 Add to your `Cargo.toml`:
 ```toml
 [dependencies]
-helius = "1.1"
+helius = "2.0"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
@@ -711,11 +711,11 @@ tokio::spawn(async move {
 ```toml
 # Default: native TLS (OpenSSL)
 [dependencies]
-helius = "1.1"
+helius = "2.0"
 
 # Alternative: rustls (pure Rust, no OpenSSL dependency)
 [dependencies]
-helius = { version = "1.1", default-features = false, features = ["rustls"] }
+helius = { version = "2.0", default-features = false, features = ["rustls"] }
 ```
 
 ## Plans and Rate Limits

--- a/src/optimized_transaction.rs
+++ b/src/optimized_transaction.rs
@@ -67,7 +67,7 @@ pub const MIN_TIP_LAMPORTS_MAX: u64 = 1_000_000; // 0.001 SOL
 /// minimum has been removed; this alias now resolves to the Sender Max minimum
 /// (0.001 SOL) for backward compatibility.
 #[deprecated(
-    since = "1.2.0",
+    since = "2.0.0",
     note = "renamed to MIN_TIP_LAMPORTS_MAX (Sender Max); value is now 0.001 SOL"
 )]
 pub const MIN_TIP_LAMPORTS_DUAL: u64 = MIN_TIP_LAMPORTS_MAX;


### PR DESCRIPTION
## Summary

This PR is release-prep for 2.0.0. We simply version and update the docs mechanics per the CLAUDE.md release checklist. Major bump because the accumulated `[Unreleased]` changes include six breaking changes

## Changes
- **`Cargo.toml`**: `1.1.0` → `2.0.0`
- **`CHANGELOG.md`**: moved `[Unreleased]` into `## [2.0.0] - 2026-08-13`; left a fresh empty `[Unreleased]`; updated the comparison links
- **`llms.txt`**: version line + all install snippets → `2.0`
- **`MIGRATION.md`**: restructured into a multi-version guide (newest first) and added a 1.x → 2.0 section with before/after for every breaking change:
  `RpcResponse<T>` optional fields, `SenderSendOptions` `#[non_exhaustive]`,
  `ProgramName::Unkown`→`Unknown`, `GetAssetsByOwner.limit` `u32`,
  `EnhancedTransaction.fee`/`slot` `u64`, and the Sender tip-tier defaults

## Verification
- `cargo test` — full suite passes
- `cargo fmt --check` — clean
- `cargo publish --dry-run` — packages `helius v2.0.0` successfully