### PR TITLE
fix websocket: handle invalid frames gracefully

### DIFF
--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -365,14 +365,24 @@ impl EnhancedWebsocket {
                   Message::Frame(_frame) => continue,
                 };
 
-                let mut json: Map<String, Value> = serde_json::from_str(&text)?;
+                let mut json: Map<String, Value> = match serde_json::from_str(&text) {
+                    Ok(j) => j,
+                    Err(e) => {
+                        log::warn!("Failed to parse websocket message: {}: {}", e, text);
+                        continue;
+                    }
+                };
 
                 // Subscribe/Unsubscribe response, example:
                 // `{"jsonrpc":"2.0","result":5308752,"id":1}`
                 if let Some(id) = json.get("id") {
-                  let id = id.as_u64().ok_or_else(|| {
-                      HeliusError::EnhancedWebsocket { reason: "invalid `id` field".into(), message: text.as_str().to_string() }
-                  })?;
+                  let id = match id.as_u64() {
+                      Some(v) => v,
+                      None => {
+                          log::warn!("Invalid id field: {}", text);
+                          continue;
+                      }
+                  };
 
                   let err = json.get("error").map(|error_object| {
                       match serde_json::from_value::<RpcErrorObject>(error_object.clone()) {
@@ -393,11 +403,16 @@ impl EnhancedWebsocket {
                         let _ = response_sender.send(Err(HeliusError::EnhancedWebsocket { reason, message: text.as_str().to_string()}));
                       },
                       None => {
-                        let json_result = json.get("result").ok_or_else(|| {
-                            HeliusError::EnhancedWebsocket { reason: "missing `result` field".into(), message: text.as_str().to_string() }
-                        })?;
+                        let json_result = match json.get("result") {
+                            Some(v) => v,
+                            None => {
+                                let _ = response_sender.send(Err(HeliusError::EnhancedWebsocket { reason: "missing `result` field".into(), message: text.clone() }));
+                                continue;
+                            }
+                        };
                         if response_sender.send(Ok(json_result.clone())).is_err() {
-                            break;
+                            log::warn!("Response receiver dropped for id {}", id);
+                            continue;
                         }
                       }
                     }
@@ -410,9 +425,13 @@ impl EnhancedWebsocket {
                       },
                       None => {
                         // Subscribe Id
-                        let sid = json.get("result").and_then(Value::as_u64).ok_or_else(|| {
-                          HeliusError::EnhancedWebsocket { reason: "invalid `result` field".into(), message: text.as_str().to_string() }
-                        })?;
+                        let sid = match json.get("result").and_then(Value::as_u64) {
+                            Some(v) => v,
+                            None => {
+                                let _ = response_sender.send(Err(HeliusError::EnhancedWebsocket { reason: "invalid `result` field".into(), message: text.clone() }));
+                                continue;
+                            }
+                        };
 
                         // Create notifications channel and unsubscribe function
                         let (notifications_sender, notifications_receiver) = mpsc::unbounded_channel();
@@ -426,14 +445,15 @@ impl EnhancedWebsocket {
                         }.boxed());
 
                         if response_sender.send(Ok((notifications_receiver, unsubscribe))).is_err() {
-                            break;
+                            log::warn!("Subscribe receiver dropped for id {}", id);
+                            continue;
                         }
                         subscriptions.insert(sid, notifications_sender);
                       }
                     }
                   } else {
-                      log::warn!("Unknown request id: {}", id);
-                      break;
+                      log::warn!("Unknown request id: {} (ignored)", id);
+                      continue;
                   }
                   continue;
                 }

--- a/src/websocket.rs
+++ b/src/websocket.rs
@@ -406,7 +406,7 @@ impl EnhancedWebsocket {
                         let json_result = match json.get("result") {
                             Some(v) => v,
                             None => {
-                                let _ = response_sender.send(Err(HeliusError::EnhancedWebsocket { reason: "missing `result` field".into(), message: text.clone() }));
+                                let _ = response_sender.send(Err(HeliusError::EnhancedWebsocket { reason: "missing `result` field".into(), message: text.to_string() }));
                                 continue;
                             }
                         };
@@ -428,7 +428,7 @@ impl EnhancedWebsocket {
                         let sid = match json.get("result").and_then(Value::as_u64) {
                             Some(v) => v,
                             None => {
-                                let _ = response_sender.send(Err(HeliusError::EnhancedWebsocket { reason: "invalid `result` field".into(), message: text.clone() }));
+                                let _ = response_sender.send(Err(HeliusError::EnhancedWebsocket { reason: "invalid `result` field".into(), message: text.to_string() }));
                                 continue;
                             }
                         };


### PR DESCRIPTION
A single malformed frame, non-numeric id, missing result, or unknown id previously broke the entire connection and dropped every active subscription. Prior to this, a server-sent frame like `{"jsonrpc":"2.0","id":999,"result":null}` with no pending id, or any non-JSON text, would `break` the `run_ws` loop.

Changes:
- `serde_json::from_str` error: log and continue instead of `?`
- `id.as_u64()` invalid: log and continue instead of `?`
- missing `result` / invalid `result`: send error to waiting request and continue
- unknown id: warn and continue instead of break
- dropped receiver: warn and continue