### PR TITLE
fix(http): default timeout, no client-build panic, simd JSON fallback

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -296,7 +296,10 @@ impl HeliusBuilder {
         let commitment = self.commitment;
         let enable_async = self.enable_async;
         let http_client = self.http_client;
-        let client = http_client.unwrap_or_else(|| Client::builder().build().expect("Failed to build HTTP client"));
+        let client = match http_client {
+            Some(c) => c,
+            None => crate::client::build_http_client()?,
+        };
 
         // Build RPC client
         let rpc_client = if let Some(commitment) = commitment {

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,4 @@
-use std::{ops::Deref, sync::Arc};
+use std::{ops::Deref, sync::Arc, time::Duration};
 
 use crate::config::Config;
 use crate::error::{HeliusError, Result};
@@ -26,6 +26,23 @@ pub struct Helius {
     pub async_rpc_client: Option<Arc<AsyncSolanaRpcClient>>,
     /// A reference-counted enhanced (geyser) websocket client
     pub ws_client: Option<Arc<EnhancedWebsocket>>,
+}
+
+/// Default request timeout applied to every HTTP client the SDK builds.
+///
+/// Without this, a stalled upstream (accepts the TCP connection but never responds) makes every
+/// SDK request hang indefinitely — there is no recovery short of killing the process. A finite
+/// default bounds that failure mode to a clear, typed error instead.
+const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Builds the shared `reqwest::Client` used for all HTTP requests made by the SDK.
+///
+/// A sane default timeout is set so a stalled connection cannot hang the caller forever.
+pub(crate) fn build_http_client() -> Result<Client> {
+    Client::builder()
+        .timeout(DEFAULT_HTTP_TIMEOUT)
+        .build()
+        .map_err(HeliusError::ReqwestError)
 }
 
 impl Helius {
@@ -60,7 +77,7 @@ impl Helius {
             custom_url: None,
         });
 
-        let client = Client::builder().build().map_err(HeliusError::ReqwestError)?;
+        let client = build_http_client()?;
         let rpc_client = Arc::new(RpcClient::new(Arc::new(client.clone()), config.clone())?);
 
         Ok(Helius {
@@ -161,7 +178,7 @@ impl Helius {
             custom_url: Some(url_string),
         });
 
-        let client = Client::builder().build().map_err(HeliusError::ReqwestError)?;
+        let client = build_http_client()?;
         let rpc_client = Arc::new(RpcClient::new(Arc::new(client.clone()), config.clone())?);
 
         Ok(Helius {
@@ -247,5 +264,19 @@ impl Deref for HeliusAsyncSolanaClient {
     /// Dereferences the wrapper to provide access to the underlying asynchronous Solana RPC client
     fn deref(&self) -> &Self::Target {
         &self.client
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_http_client_has_timeout() {
+        let client = build_http_client().unwrap();
+        assert!(
+            client.timeout().is_some(),
+            "HTTP client must be built with a default request timeout so a stalled upstream cannot hang the caller forever"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,7 +114,7 @@ impl Config {
     /// # Returns
     /// A `Result` containing a Helius client with basic RPC capabilities
     pub fn create_client(self) -> Result<Helius> {
-        let client: Client = Client::builder().build().map_err(HeliusError::ReqwestError)?;
+        let client: Client = crate::client::build_http_client()?;
         let rpc_client: Arc<RpcClient> = Arc::new(self.rpc_client_with_reqwest_client(client.clone())?);
 
         Ok(Helius {
@@ -131,7 +131,7 @@ impl Config {
     /// # Returns
     /// A `Result` containing a Helius client with both RPC and async Solana capabilities
     pub fn create_client_with_async(self) -> Result<Helius> {
-        let client: Client = Client::builder().build().map_err(HeliusError::ReqwestError)?;
+        let client: Client = crate::client::build_http_client()?;
         let rpc_url = self.build_rpc_url();
 
         let async_solana_client: Arc<AsyncSolanaRpcClient> = Arc::new(AsyncSolanaRpcClient::new(rpc_url));
@@ -159,7 +159,7 @@ impl Config {
         ping_interval_secs: Option<u64>,
         pong_timeout_secs: Option<u64>,
     ) -> Result<Helius> {
-        let client: Client = Client::builder().build().map_err(HeliusError::ReqwestError)?;
+        let client: Client = crate::client::build_http_client()?;
         let rpc_client: Arc<RpcClient> = Arc::new(self.rpc_client_with_reqwest_client(client.clone())?);
 
         let api_key = self.require_api_key("WebSocket connections")?;
@@ -189,7 +189,7 @@ impl Config {
         ping_interval_secs: Option<u64>,
         pong_timeout_secs: Option<u64>,
     ) -> Result<Helius> {
-        let client: Client = Client::builder().build().map_err(HeliusError::ReqwestError)?;
+        let client: Client = crate::client::build_http_client()?;
         let rpc_client: Arc<RpcClient> = Arc::new(self.rpc_client_with_reqwest_client(client.clone())?);
 
         // Setup async client

--- a/src/request_handler.rs
+++ b/src/request_handler.rs
@@ -109,10 +109,11 @@ impl RequestHandler {
             // parsed transaction history) but mutates its input buffer in place, so we hand it
             // owned bytes via `String::into_bytes`. Falls through to a `serde_json` retry on
             // error to surface the more descriptive parser diagnostics for debugging.
+            let body_text_for_fallback = body_text.clone();
             let mut body_bytes: Vec<u8> = body_text.into_bytes();
             match simd_json::serde::from_slice::<T>(&mut body_bytes) {
                 Ok(data) => Ok(data),
-                Err(simd_err) => match serde_json::from_slice::<T>(&body_bytes) {
+                Err(simd_err) => match serde_json::from_slice::<T>(body_text_for_fallback.as_bytes()) {
                     Ok(data) => Ok(data),
                     Err(serde_err) => {
                         let raw: String = String::from_utf8_lossy(&body_bytes).into_owned();


### PR DESCRIPTION
## Summary
- **Default HTTP timeout**: every `reqwest::Client` the SDK builds now has a 30s default timeout. Previously `Client::builder().build()` had no timeout, so a stalled upstream (accepts the TCP connection but never responds) would hang the caller forever with no recovery short of killing the process.
- **No client-build panic**: `HeliusBuilder` built the client with `Client::builder().build().expect("Failed to build HTTP client")`. A build failure now returns a typed `HeliusError` instead of panicking the whole process.
- **simd_json buffer reuse**: `simd_json::serde::from_slice` mutates the buffer in place, so the `serde_json` fallback path was deserializing already-mutated bytes. The fallback now parses a fresh copy of the original text.

## Why these three
All three are low-risk, high-confidence correctness bugs found by reading the client-construction and response-parsing paths. None change the public API surface.

## Proof (fail-when-reverted test)
Added `default_http_client_has_timeout` in `src/client.rs`. On the pre-fix code (`Client::builder().build()` with no `.timeout()`) it fails because `client.timeout().is_some()` is `false`; after the fix it passes. CI is the source of truth (cannot run `cargo test` locally — the solana dependencies exceed available disk).

## Risk
- 30s is a generous default; requests that legitimately exceed it now return a typed timeout error instead of hanging. Making the timeout configurable is a natural follow-up.
- Not included here (separate, more invasive PRs planned): send-transaction busy-loop without backoff, epoch off-by-one in `get_withdrawable_amount`, per-call client creation in the sender path.

## Test plan
- [x] `default_http_client_has_timeout` added (fails before / passes after)
- [ ] CI `cargo test` / `cargo clippy`
