### PR TITLE
feat(solana): support Agave 4.3.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Changed
+- Upgraded the Solana dependencies to Agave 4.3.0-beta.3 and wincode 0.6.1. The minimum supported Rust version is now 1.97.1, matching Agave.
 - **`send_and_confirm_transaction` gained `Clone + Send + 'static` bounds** on its transaction parameter (`transaction: &impl SerializableTransaction` became a named generic `T`). Each send attempt now runs on the blocking pool, which needs an owned value outliving the call frame, so the transaction is cloned per attempt. `Transaction` and `VersionedTransaction` both satisfy the bounds, so callers passing either are unaffected; a caller passing a custom `SerializableTransaction` type must add the bounds.
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "helius"
 version = "2.0.0"
-rust-version = "1.85.1"
+rust-version = "1.97.1"
 edition = "2021"
 description = "An asynchronous Helius Rust SDK for building the future of Solana"
 keywords = ["helius", "solana", "asynchronous-sdk", "das", "cryptocurrency"]
@@ -27,17 +27,17 @@ serde = "1.0.198"
 serde-enum-str = "0.4.0"
 serde_json = "1.0.116"
 simd-json = "0.15.1"
-solana-account-decoder = "4.2.1"
-solana-client = "4.2.1"
+solana-account-decoder = "=4.3.0-beta.3"
+solana-client = "=4.3.0-beta.3"
 solana-commitment-config = "3.1.1"
-solana-compute-budget-interface = "3.0.0"
-solana-rpc-client-api = "4.2.1"
+solana-compute-budget-interface = "3.1.0"
+solana-rpc-client-api = "=4.3.0-beta.3"
 solana-sdk = "4.0.1"
-solana-stake-interface = "4.3.0"
-solana-system-interface = "2.0.0"
+solana-stake-interface = "4.4.0"
+solana-system-interface = "3.3.0"
 # The parent `solana-transaction-status` crate is gated behind the `agave-unstable-api` feature
 # in 4.x; the wire/status types we use live in this ungated companion crate.
-solana-transaction-status-client-types = "4.2.1"
+solana-transaction-status-client-types = "=4.3.0-beta.3"
 thiserror = "2.0.17"
 tokio = { version = "1.37.0", features = ["macros", "rt-multi-thread", "net", "time"] }
 tokio-stream = "0.1.15"
@@ -45,7 +45,7 @@ tokio-tungstenite = "0.28.0"
 url = "2.5.0"
 # Transaction v1 (SIMD-0385) uses the wincode wire format, not bincode. Pinned to the version the
 # solana 4.x crates use so the `SchemaWrite` impl resolves to the same type.
-wincode = "0.5.5"
+wincode = "0.6.1"
 
 [dev-dependencies]
 mockito = "1.4.0"


### PR DESCRIPTION
## Summary

- upgrade the SDK's Agave dependencies from 4.2.1 to 4.3.0-beta.3
- align related interface crates and `wincode` with the beta release
- raise the MSRV to Rust 1.97.1, matching Agave 4.3.0-beta.3

This is a dependency-only compatibility update for archival devnet testing. It does not publish a new SDK release or include the custom fast-base58 patch.

## Validation

- `cargo +1.97.1 fmt --all -- --check`
- `cargo +1.97.1 build`
- `cargo +1.97.1 clippy --all-targets`
- `cargo +1.97.1 test`
