### PR TITLE
fix(sender): Bound the Auto-Derived Sender Tip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Security
+- **The auto-derived Sender tip had no upper bound.** `determine_tip_lamports` read the 75th-percentile tip floor from a third-party feed (Jito's `bundles.jito.wtf` endpoint) and applied only `.max(minimum)` — a floor, never a ceiling — then paid the result as a real `system_instruction::transfer` out of the fee payer's account. `SenderSendOptions` gave the caller no way to bound it. Two consequences: an ordinary tip spike during congestion silently charged far more than the 0.001 SOL a caller expected, and a compromised or malfunctioning feed could propose an arbitrary amount, up to draining the payer into the tip account. The priority fee already had `priority_fee_cap`; the tip — larger and unconditional — had nothing.
+
+  The derived tip is now **clamped** between the tier minimum and a ceiling, and the feed value is validated before use (non-finite, negative, and implausibly large readings are rejected with a warning and fall back to the minimum, instead of being cast straight into a transfer).
+
+  Safe by default: `determine_tip_lamports` keeps its signature and now applies `DEFAULT_MAX_TIP_LAMPORTS` (0.01 SOL, 10x the Sender Max minimum), so existing callers are bounded without a code change. Set your own ceiling via `SenderSendOptions::with_max_tip_lamports` or `determine_tip_lamports_with_cap`. A ceiling below the tier's minimum tip is unsatisfiable and returns `HeliusError::InvalidInput` rather than silently paying above it. This bounds only the *derived* tip — a tip you build into the instructions yourself is untouched.
+
 ### Changed
 - **`send_and_confirm_transaction` gained `Clone + Send + 'static` bounds** on its transaction parameter (`transaction: &impl SerializableTransaction` became a named generic `T`). Each send attempt now runs on the blocking pool, which needs an owned value outliving the call frame, so the transaction is cloned per attempt. `Transaction` and `VersionedTransaction` both satisfy the bounds, so callers passing either are unaffected; a caller passing a custom `SerializableTransaction` type must add the bounds.
 
 ### Added
+- `SenderSendOptions::max_tip_lamports` (with a `with_max_tip_lamports` builder), `Helius::determine_tip_lamports_with_cap`, and the `DEFAULT_MAX_TIP_LAMPORTS` constant, for bounding the auto-derived Sender tip. `SenderSendOptions` is `#[non_exhaustive]` and constructed via `default()`/`new()` plus builders, so the new field is additive.
 - `Helius::poll_transaction_confirmation_with_timeout` and the `DEFAULT_CONFIRMATION_POLL_TIMEOUT` constant, so a caller holding an overall deadline can bound a confirmation poll by the time actually remaining rather than by the fixed default. `poll_transaction_confirmation` is unchanged and delegates to it with the default.
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Admin API access is feature-gated per project and served from `https://admin-api
 
 ### Helius Sender
 - [`create_smart_transaction_with_tip_for_sender`](https://github.com/helius-labs/helius-rust-sdk/blob/47d68afcf644938bc474f609368b214170423bba/src/optimized_transaction.rs#L978-L1007) - Creates an optimized smart transaction with an appended tip transfer instruction for Sender
-- [`determine_tip_lamports`](https://github.com/helius-labs/helius-rust-sdk/blob/47d68afcf644938bc474f609368b214170423bba/src/optimized_transaction.rs#L966-L976) - Determines the tip amount in lamports using the 75th percentile floor or falling back to the minimum required by Sender
+- [`determine_tip_lamports`](https://github.com/helius-labs/helius-rust-sdk/blob/47d68afcf644938bc474f609368b214170423bba/src/optimized_transaction.rs#L966-L976) - Determines the tip amount in lamports from the 75th-percentile tip floor, clamped between the tier minimum required by Sender and a ceiling (`DEFAULT_MAX_TIP_LAMPORTS`, or `SenderSendOptions::max_tip_lamports`)
 - [`fetch_tip_floor_75th`](https://github.com/helius-labs/helius-rust-sdk/blob/47d68afcf644938bc474f609368b214170423bba/src/optimized_transaction.rs#L940-L964) - Fetches the 75th percentile landed tip floor from Jito's endpoint (in SOL)
 - [`send_and_confirm_via_sender`](https://github.com/helius-labs/helius-rust-sdk/blob/47d68afcf644938bc474f609368b214170423bba/src/optimized_transaction.rs#L1023-L1071) - Send a signed tx via Sender `/fast` and poll until confirmed (or until timeout/last valid blockhash expiry)
 - [`send_smart_transaction_with_sender`](https://github.com/helius-labs/helius-rust-sdk/blob/dev/src/optimized_transaction.rs) - Builds an optimized tx and sends it via Sender

--- a/src/optimized_transaction.rs
+++ b/src/optimized_transaction.rs
@@ -79,6 +79,29 @@ pub const MIN_TIP_LAMPORTS_DUAL: u64 = MIN_TIP_LAMPORTS_MAX;
 /// Minimum tip: 0.000005 SOL (5,000 lamports).
 pub const MIN_TIP_LAMPORTS_SWQOS: u64 = 5_000; // 0.000005 SOL
 
+/// Default hard ceiling on the auto-derived Sender tip: 0.01 SOL, 10x the Sender Max minimum.
+///
+/// The tip is read from a third-party feed and paid as a real transfer out of the fee payer's
+/// account, so it needs an upper bound as well as a lower one. 10x leaves ample room for genuine
+/// congestion — the 75th-percentile landed tip normally sits three orders of magnitude below this
+/// — while bounding the loss if the feed spikes or is tampered with.
+///
+/// Override per-send with [`SenderSendOptions::with_max_tip_lamports`](crate::types::SenderSendOptions::with_max_tip_lamports).
+pub const DEFAULT_MAX_TIP_LAMPORTS: u64 = 10_000_000; // 0.01 SOL
+
+// Satisfiability only: a default below the tier minimum would fail every default-configured send.
+// The 10x headroom is deliberately not asserted, so tuning the default is not a build break.
+const _: () = assert!(
+    DEFAULT_MAX_TIP_LAMPORTS >= MIN_TIP_LAMPORTS_MAX,
+    "DEFAULT_MAX_TIP_LAMPORTS must be satisfiable on the Sender Max tier"
+);
+
+/// Largest tip-floor value, in SOL, accepted from the feed. Anything above is treated as malformed.
+///
+/// Guards the parse independently of the per-send ceiling, so a broken or compromised feed cannot
+/// propose an absurd tip in the first place.
+const MAX_PLAUSIBLE_TIP_FLOOR_SOL: f64 = 1.0;
+
 /// Maximum serialized size of a Transaction v1 (SIMD-0296), in bytes.
 ///
 /// Agave 4.2 activates larger transactions: v1 (SIMD-0385) raises the cap from the legacy/v0
@@ -261,6 +284,36 @@ fn collect_unique_keypair_refs<'a>(signers: &'a [Keypair], fee_payer: &'a Keypai
 /// [`Helius::poll_transaction_confirmation_with_timeout`] and pass the time remaining, so a poll
 /// cannot overrun the budget the caller was given.
 pub const DEFAULT_CONFIRMATION_POLL_TIMEOUT: Duration = Duration::from_secs(15);
+
+/// Converts a tip-floor reading in SOL to lamports. `None` for anything that cannot be a real tip
+/// floor, leaving the caller to fall back to the tier minimum.
+fn tip_floor_sol_to_lamports(sol: f64) -> Option<u64> {
+    // Catches NaN and both infinities too: every comparison against NaN is false, so `contains`
+    // is false for them.
+    if !(0.0..=MAX_PLAUSIBLE_TIP_FLOOR_SOL).contains(&sol) {
+        log::warn!("Ignoring implausible tip-floor value from feed: {sol} SOL");
+        return None;
+    }
+
+    Some((sol * 1_000_000_000.0) as u64)
+}
+
+/// Resolves the tip to pay: a missing or rejected feed reading falls back to the minimum, and the
+/// result is *clamped*, not merely floored.
+///
+/// Callers reject an unsatisfiable ceiling before calling, since only they can attribute it. The
+/// bounds are normalized anyway so this cannot panic the way a bare `clamp` would; the
+/// `debug_assert` keeps that misuse loud in tests.
+fn resolve_tip_lamports(feed_lamports: Option<u64>, min_lamports: u64, max_tip_lamports: u64) -> u64 {
+    debug_assert!(
+        max_tip_lamports >= min_lamports,
+        "tip ceiling must not sit below the tier minimum"
+    );
+
+    let ceiling: u64 = max_tip_lamports.max(min_lamports);
+
+    feed_lamports.unwrap_or(min_lamports).clamp(min_lamports, ceiling)
+}
 
 fn is_retryable_confirmation_error(err: &HeliusError) -> bool {
     matches!(err, HeliusError::Timeout { .. })
@@ -1456,19 +1509,56 @@ impl Helius {
             .and_then(|o| o.get("landed_tips_75th_percentile"))
             .and_then(|v| v.as_f64());
 
-        Ok(val_sol.map(|sol| (sol * 1_000_000_000.0) as u64))
+        Ok(val_sol.and_then(tip_floor_sol_to_lamports))
     }
 
-    /// Determines the tip amount in lamports using the 75th percentile floor or falling back to the minimum.
+    /// Determines the tip amount in lamports from the 75th-percentile tip floor, bounded below by
+    /// the tier minimum and above by [`DEFAULT_MAX_TIP_LAMPORTS`].
+    ///
+    /// To choose the ceiling yourself, use [`Helius::determine_tip_lamports_with_cap`].
+    ///
+    /// # Arguments
+    /// * `swqos_only` - Selects the tier, and with it the minimum tip
+    ///
+    /// # Returns
+    /// The tip in lamports, within `[tier minimum, DEFAULT_MAX_TIP_LAMPORTS]`
     pub async fn determine_tip_lamports(&self, swqos_only: bool) -> Result<u64> {
+        self.determine_tip_lamports_with_cap(swqos_only, DEFAULT_MAX_TIP_LAMPORTS)
+            .await
+    }
+
+    /// Determines the tip amount in lamports, bounded below by the tier minimum and above by
+    /// `max_tip_lamports`. See [`DEFAULT_MAX_TIP_LAMPORTS`] for why the ceiling exists.
+    ///
+    /// # Arguments
+    /// * `swqos_only` - Selects the tier, and with it the minimum tip
+    /// * `max_tip_lamports` - Hard ceiling on the derived tip
+    ///
+    /// # Returns
+    /// The tip in lamports, within `[tier minimum, max_tip_lamports]`
+    ///
+    /// # Errors
+    /// [`HeliusError::InvalidInput`] if `max_tip_lamports` is below the tier's minimum tip — no tip
+    /// satisfies both bounds, and paying above the caller's ceiling would defeat setting one.
+    /// Validated before the feed is contacted, so a misconfiguration costs no network call.
+    pub async fn determine_tip_lamports_with_cap(&self, swqos_only: bool, max_tip_lamports: u64) -> Result<u64> {
         let min_lamports: u64 = if swqos_only {
             MIN_TIP_LAMPORTS_SWQOS
         } else {
             MIN_TIP_LAMPORTS_MAX
         };
-        let floor_lamports: u64 = self.fetch_tip_floor_75th().await?.unwrap_or(min_lamports);
 
-        Ok(floor_lamports.max(min_lamports))
+        if max_tip_lamports < min_lamports {
+            return Err(HeliusError::InvalidInput(format!(
+                "max_tip_lamports ({max_tip_lamports}) is below the minimum tip for this tier \
+                 ({min_lamports} lamports, {tier}); raise the ceiling or switch tiers",
+                tier = if swqos_only { "SWQOS-only" } else { "Sender Max" },
+            )));
+        }
+
+        let feed_lamports: Option<u64> = self.fetch_tip_floor_75th().await?;
+
+        Ok(resolve_tip_lamports(feed_lamports, min_lamports, max_tip_lamports))
     }
 
     /// Creates an optimized smart transaction with an appended tip transfer instruction for Sender
@@ -1587,17 +1677,11 @@ impl Helius {
             return Err(HeliusError::InvalidInput("Sender region must be specified".to_string()));
         }
 
-        // Determine tip and enforce floor (all in lamports)
-        let mut tip_lamports = self.determine_tip_lamports(sender_opts.swqos_only).await?;
-        let floor = if sender_opts.swqos_only {
-            MIN_TIP_LAMPORTS_SWQOS
-        } else {
-            MIN_TIP_LAMPORTS_MAX
-        };
-
-        if tip_lamports < floor {
-            tip_lamports = floor;
-        }
+        // The clamp lives in `determine_tip_lamports_with_cap`; a separate floor pass here would
+        // only mask a ceiling that was set too low.
+        let tip_lamports: u64 = self
+            .determine_tip_lamports_with_cap(sender_opts.swqos_only, sender_opts.max_tip_lamports)
+            .await?;
 
         let create_cfg: CreateSmartTransactionConfig = config.create_config;
 
@@ -1758,7 +1842,8 @@ impl Helius {
 mod tests {
     use super::{
         build_v1_transaction, collect_unique_keypair_refs, collect_unique_signers, is_retryable_confirmation_error,
-        v1_priority_fee_lamports, MAX_TRANSACTION_V1_SIZE,
+        resolve_tip_lamports, tip_floor_sol_to_lamports, v1_priority_fee_lamports, DEFAULT_MAX_TIP_LAMPORTS,
+        MAX_PLAUSIBLE_TIP_FLOOR_SOL, MAX_TRANSACTION_V1_SIZE, MIN_TIP_LAMPORTS_MAX, MIN_TIP_LAMPORTS_SWQOS,
     };
 
     /// The v1 total-lamports fee conversion must stay the exact inverse of Atlas's
@@ -2059,5 +2144,84 @@ mod tests {
         assert!(is_retryable_confirmation_error(&timeout));
         assert!(!is_retryable_confirmation_error(&tx_error));
         assert!(!is_retryable_confirmation_error(&invalid_input));
+    }
+
+    /// The tip-floor feed is third-party input that turns directly into a signed transfer, so
+    /// anything that cannot be a real tip floor is rejected rather than cast.
+    #[test]
+    fn tip_floor_rejects_values_that_cannot_be_a_tip_floor() {
+        assert_eq!(tip_floor_sol_to_lamports(f64::NAN), None, "NaN");
+        assert_eq!(tip_floor_sol_to_lamports(f64::INFINITY), None, "infinity");
+        assert_eq!(tip_floor_sol_to_lamports(f64::NEG_INFINITY), None, "negative infinity");
+        assert_eq!(tip_floor_sol_to_lamports(-0.5), None, "negative");
+        assert_eq!(
+            tip_floor_sol_to_lamports(MAX_PLAUSIBLE_TIP_FLOOR_SOL + 0.1),
+            None,
+            "above the plausible bound"
+        );
+        assert_eq!(tip_floor_sol_to_lamports(1_000_000.0), None, "absurd");
+    }
+
+    /// Ordinary readings convert cleanly, including the boundary value itself.
+    #[test]
+    fn tip_floor_accepts_plausible_values() {
+        // A typical reading: 0.000024871 SOL.
+        assert_eq!(tip_floor_sol_to_lamports(0.000_024_871), Some(24_871));
+        assert_eq!(tip_floor_sol_to_lamports(0.0), Some(0), "zero is a valid floor");
+        assert_eq!(
+            tip_floor_sol_to_lamports(MAX_PLAUSIBLE_TIP_FLOOR_SOL),
+            Some(1_000_000_000),
+            "the bound itself is inclusive"
+        );
+    }
+
+    /// The clamp is the fix: previously the feed was only floored, so an arbitrarily large reading
+    /// became an arbitrarily large transfer.
+    #[test]
+    fn resolve_tip_clamps_to_both_bounds() {
+        let min = MIN_TIP_LAMPORTS_MAX;
+        let max = DEFAULT_MAX_TIP_LAMPORTS;
+
+        assert_eq!(
+            resolve_tip_lamports(None, min, max),
+            min,
+            "no reading falls back to the minimum"
+        );
+        assert_eq!(
+            resolve_tip_lamports(Some(0), min, max),
+            min,
+            "below the minimum is raised"
+        );
+        assert_eq!(
+            resolve_tip_lamports(Some(min + 1), min, max),
+            min + 1,
+            "a reading inside the bounds is used as-is"
+        );
+        assert_eq!(
+            resolve_tip_lamports(Some(max), min, max),
+            max,
+            "the ceiling is inclusive"
+        );
+        assert_eq!(
+            resolve_tip_lamports(Some(max + 1), min, max),
+            max,
+            "above the ceiling is capped — this is what used to be unbounded"
+        );
+        assert_eq!(
+            resolve_tip_lamports(Some(u64::MAX), min, max),
+            max,
+            "a hostile feed value cannot exceed the ceiling"
+        );
+    }
+
+    /// The SWQOS tier has a much lower minimum, and the same clamp applies against it.
+    #[test]
+    fn resolve_tip_respects_the_swqos_minimum() {
+        let min = MIN_TIP_LAMPORTS_SWQOS;
+        let max = DEFAULT_MAX_TIP_LAMPORTS;
+
+        assert_eq!(resolve_tip_lamports(None, min, max), MIN_TIP_LAMPORTS_SWQOS);
+        assert_eq!(resolve_tip_lamports(Some(1), min, max), MIN_TIP_LAMPORTS_SWQOS);
+        assert_eq!(resolve_tip_lamports(Some(u64::MAX), min, max), max);
     }
 }

--- a/src/types/inner.rs
+++ b/src/types/inner.rs
@@ -1988,6 +1988,18 @@ pub struct SenderSendOptions {
     /// Poll settings
     pub poll_timeout_ms: u64,
     pub poll_interval_ms: u64,
+    /// Hard ceiling, in lamports, on the tip the SDK derives automatically. Defaults to
+    /// [`DEFAULT_MAX_TIP_LAMPORTS`] (0.01 SOL).
+    ///
+    /// Bounds only the *derived* tip; a tip you build into the instructions yourself is untouched.
+    /// Must be at least the tier's minimum ([`MIN_TIP_LAMPORTS_MAX`], or [`MIN_TIP_LAMPORTS_SWQOS`]
+    /// when `swqos_only`) — a lower ceiling is unsatisfiable and fails the send rather than paying
+    /// above it.
+    ///
+    /// [`DEFAULT_MAX_TIP_LAMPORTS`]: crate::optimized_transaction::DEFAULT_MAX_TIP_LAMPORTS
+    /// [`MIN_TIP_LAMPORTS_MAX`]: crate::optimized_transaction::MIN_TIP_LAMPORTS_MAX
+    /// [`MIN_TIP_LAMPORTS_SWQOS`]: crate::optimized_transaction::MIN_TIP_LAMPORTS_SWQOS
+    pub max_tip_lamports: u64,
 }
 
 impl Default for SenderSendOptions {
@@ -1998,6 +2010,7 @@ impl Default for SenderSendOptions {
             skip_preflight: true,
             poll_timeout_ms: 60_000,
             poll_interval_ms: 2_000,
+            max_tip_lamports: crate::optimized_transaction::DEFAULT_MAX_TIP_LAMPORTS,
         }
     }
 }
@@ -2035,6 +2048,14 @@ impl SenderSendOptions {
     /// Sets the poll interval in milliseconds.
     pub fn with_poll_interval_ms(mut self, poll_interval_ms: u64) -> Self {
         self.poll_interval_ms = poll_interval_ms;
+        self
+    }
+
+    /// Sets the hard ceiling on the auto-derived tip, in lamports.
+    ///
+    /// See [`SenderSendOptions::max_tip_lamports`]. Must be at least the tier's minimum tip.
+    pub fn with_max_tip_lamports(mut self, max_tip_lamports: u64) -> Self {
+        self.max_tip_lamports = max_tip_lamports;
         self
     }
 }

--- a/tests/smart_transactions/test_sender_tip.rs
+++ b/tests/smart_transactions/test_sender_tip.rs
@@ -1,0 +1,134 @@
+use helius::error::HeliusError;
+use helius::optimized_transaction::{DEFAULT_MAX_TIP_LAMPORTS, MIN_TIP_LAMPORTS_MAX, MIN_TIP_LAMPORTS_SWQOS};
+use helius::types::{SenderSendOptions, SmartTransactionConfig, Timeout};
+
+use std::sync::Arc;
+
+use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::{Keypair, Signer};
+use solana_system_interface::instruction as system_instruction;
+
+use super::helpers::setup_mock;
+
+/// A ceiling below the tier minimum is unsatisfiable: no tip is both at least the minimum and at
+/// most the ceiling. It fails fast rather than silently paying above the stated ceiling, and it
+/// fails *before* the tip-floor feed is contacted, so a misconfiguration costs no network call.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ceiling_below_tier_minimum_is_rejected() {
+    let (_server, helius) = setup_mock().await;
+
+    let result = helius
+        .determine_tip_lamports_with_cap(false, MIN_TIP_LAMPORTS_MAX - 1)
+        .await;
+
+    let err = result.expect_err("a ceiling below the Sender Max minimum should be rejected");
+    assert!(
+        matches!(err, HeliusError::InvalidInput(_)),
+        "expected InvalidInput, got {err:?}"
+    );
+    assert!(
+        err.to_string().contains("max_tip_lamports"),
+        "the error should name the offending option, got {err}"
+    );
+    assert!(
+        err.to_string().contains("Sender Max"),
+        "the error should name the tier whose minimum was violated, got {err}"
+    );
+}
+
+/// The SWQOS tier has its own, much lower minimum, and the same rule applies against it.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_ceiling_below_swqos_minimum_is_rejected() {
+    let (_server, helius) = setup_mock().await;
+
+    let result = helius
+        .determine_tip_lamports_with_cap(true, MIN_TIP_LAMPORTS_SWQOS - 1)
+        .await;
+
+    let err = result.expect_err("a ceiling below the SWQOS minimum should be rejected");
+    assert!(
+        matches!(err, HeliusError::InvalidInput(_)),
+        "expected InvalidInput, got {err:?}"
+    );
+    assert!(
+        err.to_string().contains("SWQOS-only"),
+        "the error should name the SWQOS tier, not Sender Max, got {err}"
+    );
+
+    // The bound is per-tier: a ceiling that clears the SWQOS minimum still fails on Sender Max.
+    // Asserted through the rejection rather than the accepting path, because a passing validation
+    // continues on to the live tip-floor feed and this suite does not make network calls.
+    let on_sender_max = helius
+        .determine_tip_lamports_with_cap(false, MIN_TIP_LAMPORTS_SWQOS)
+        .await;
+    assert!(
+        matches!(on_sender_max, Err(HeliusError::InvalidInput(_))),
+        "the SWQOS minimum is far below the Sender Max minimum and must be rejected there, got {on_sender_max:?}"
+    );
+}
+
+/// Callers who never touch the new option still get a bounded tip: this is the safe-by-default
+/// half of the fix, and the reason `determine_tip_lamports` keeps its signature.
+#[test]
+fn test_default_options_carry_a_tip_ceiling() {
+    let options = SenderSendOptions::default();
+
+    assert_eq!(
+        options.max_tip_lamports, DEFAULT_MAX_TIP_LAMPORTS,
+        "default options must carry the default ceiling"
+    );
+    assert!(
+        options.max_tip_lamports >= MIN_TIP_LAMPORTS_MAX,
+        "the default ceiling must be satisfiable on the default (Sender Max) tier"
+    );
+}
+
+/// The builder sets the ceiling and leaves the rest of the defaults alone.
+#[test]
+fn test_builder_sets_the_tip_ceiling() {
+    let options = SenderSendOptions::new()
+        .with_swqos_only(true)
+        .with_max_tip_lamports(50_000);
+
+    assert_eq!(options.max_tip_lamports, 50_000);
+    assert!(options.swqos_only);
+    assert_eq!(
+        options.poll_timeout_ms,
+        SenderSendOptions::default().poll_timeout_ms,
+        "unrelated defaults should be untouched"
+    );
+}
+
+/// The ceiling has to actually reach the clamp. `send_smart_transaction_with_sender` reads it off
+/// `SenderSendOptions`, so an unsatisfiable ceiling must surface from the public send path — which
+/// it can only do if the option is threaded through rather than dropped.
+///
+/// This also pins the ordering: validation happens before the tip-floor feed is contacted and
+/// before anything is signed or submitted, so a misconfiguration costs no network call and cannot
+/// half-send a transaction.
+#[tokio::test(flavor = "multi_thread")]
+async fn test_send_path_threads_the_ceiling_through() {
+    let (_server, helius) = setup_mock().await;
+
+    let payer = Keypair::new();
+    let instructions = vec![system_instruction::transfer(&payer.pubkey(), &Pubkey::new_unique(), 1)];
+    let config = SmartTransactionConfig::new(
+        instructions,
+        vec![Arc::new(payer) as Arc<dyn Signer>],
+        Timeout::default(),
+    );
+
+    let options = SenderSendOptions::new().with_max_tip_lamports(MIN_TIP_LAMPORTS_MAX - 1);
+
+    let result = helius.send_smart_transaction_with_sender(config, options).await;
+
+    let err = result.expect_err("an unsatisfiable ceiling should fail the send");
+    assert!(
+        matches!(err, HeliusError::InvalidInput(_)),
+        "expected InvalidInput, got {err:?}"
+    );
+    assert!(
+        err.to_string().contains("max_tip_lamports"),
+        "the ceiling from SenderSendOptions should be the one that was validated, got {err}"
+    );
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -54,6 +54,7 @@ mod smart_transactions {
     mod test_input_validation;
     mod test_poll_confirmation;
     mod test_send_and_confirm;
+    mod test_sender_tip;
     mod test_sender_urls;
 }
 mod websocket {


### PR DESCRIPTION
## The problem

`determine_tip_lamports` derived the Sender tip like this:

```rust
let floor_lamports = self.fetch_tip_floor_75th().await?.unwrap_or(min_lamports);
Ok(floor_lamports.max(min_lamports))   // only a floor; nothing caps the top end
```

`fetch_tip_floor_75th` reads `landed_tips_75th_percentile` from `https://bundles.jito.wtf`, multiplies it into lamports with a bare `as u64` cast, and the result becomes a real `system_instruction::transfer` out of the fee payer's account. `.max()` enforces a minimum only. `SenderSendOptions` had nowhere to put a ceiling

Two ways this hurts, and the first needs no attacker:

- Jito tips spike during congestion. A caller expecting to pay the 0.001 SOL minimum could silently sign away far more on a busy day
- The feed is a bare `reqwest::get` with no pinning and no sanity check, so a compromise or DNS/cert trick could set the value just under the payer's balance—the transaction still lands, and the wallet empties into the tip account

The priority fee already had `priority_fee_cap`, but the tip had nothing

## The fix

The derived tip is bounded on both sides

**The feed is validated before use.** Non-finite, negative, and implausibly large readings (> 1 SOL) are rejected with a warning and fall back to the tier minimum, rather than being cast into a transfer. This guards the parse independently of the per-send ceiling, so a broken feed cannot propose an absurd tip in the first place

**Safe by default.** `determine_tip_lamports` keeps its signature and now applies `DEFAULT_MAX_TIP_LAMPORTS`, so every existing caller is bounded without touching their code. `determine_tip_lamports_with_cap` is the explicit escape hatch

**Unsatisfiable ceilings fail loudly:**

```
max_tip_lamports (500000) is below the minimum tip for this tier (1000000 lamports, Sender Max); raise the ceiling or switch tiers
```

Note that this bounds only the derived tip. `send_bundle_with_sender` and `create_smart_transaction_with_tip_for_sender` take caller-supplied tips and are deliberately untouched

## API

```
+ pub const DEFAULT_MAX_TIP_LAMPORTS: u64
+ pub async fn determine_tip_lamports_with_cap(&self, swqos_only: bool, max_tip_lamports: u64)
+ pub max_tip_lamports: u64            // on SenderSendOptions
+ pub fn with_max_tip_lamports(self, max_tip_lamports: u64)
```

`SenderSendOptions` is `#[non_exhaustive]` and built via `default()`/`new()` plus builders, so the new field is non-breaking. No existing signature changed

## Testing

Nine tests, each verified to fail against the pre-fix behavior:

- `resolve_tip_clamps_to_both_bounds` — fails with "above the ceiling is capped—this is what used to be unbounded" when reverted to `.max()`. Covers `u64::MAX` from a hostile feed
- `test_send_path_threads_the_ceiling_through` — drives the real public send path and fails if `sender_opts.max_tip_lamports` is dropped. This is the wiring most likely to regress silently
- Feed rejection across NaN, ±infinity, negative, and absurd values, plus inclusive boundary acceptance
- Per-tier ceiling validation for both Sender Max and SWQOS

Also:
- cargo fmt --check` clean, clippy 0 warnings, 368 tests pass**. 4 rustdoc warnings, all pre-existing in `websocket.rs`, `error.rs`, and`enums.rs`